### PR TITLE
Demosaicing: Add AHD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 nopush_*
 *.dng*
 *.png*
+debayer/ahd_homogeneity_cython.c

--- a/base_types/image_base.py
+++ b/base_types/image_base.py
@@ -1,0 +1,97 @@
+from typing import Optional
+import numpy as np
+
+from pySP.const import QualityDemosaic
+
+class RawDebayerData():
+    def __init__(self, image : np.ndarray, wb_coeff : np.ndarray, wb_norm : bool = False):
+        """Class for storing RGB pixel data after debayering.
+
+        Args:
+            image (np.ndarray): RGB pixel data in shape (height, width, 3). Should be normalized and with colors in camera-space after applying white balance correction.
+            wb_coeff (np.ndarray): White balance co-efficients. Should have minimum length of 3.
+            wb_norm (bool, optional): Optional flag to set whether white-balanced was applied in normalizing or naive way. Defaults to False, meaning naive application (multiplied through).
+        """
+
+        self.image              : np.ndarray = image
+        self._wb_coeff          : np.ndarray = wb_coeff
+        self._wb_applied        : bool = True
+        self._wb_normalized     : bool = wb_norm
+        
+        self.mat_xyz            : np.ndarray = None
+        self.current_ev         : float = np.inf
+        
+    def is_valid(self) -> bool:
+        """Check if contents of this image are valid, i.e., are expected.
+
+        Returns:
+            bool: True if image is valid; False otherwise.
+        """
+        return type(self.image) != type(None) and type(self._wb_coeff) != type(None) and type(self.mat_xyz) != type(None) and self.current_ev != np.inf
+    
+    def wb_apply(self):
+        """Apply white balance co-efficients if not already applied.
+        """
+        if not(self._wb_applied):
+            self.image = (self.image * self._wb_coeff[:3]).astype(np.float32)
+            self._wb_applied = True
+    
+    def wb_undo(self):
+        """Undo white balance to return to pure camera-space if white balance was applied. Removes normalization in process.
+        """
+        if self._wb_applied:
+            if self._wb_normalized:
+                self.image = self.image * max(self._wb_coeff)
+            self.image = (self.image.astype(np.float64) / self._wb_coeff[:3]).astype(np.float32)
+            self._wb_applied = False
+            self._wb_normalized = False
+
+class RawRgbgData_BaseType():
+    def __init__(self):
+        """Base class for storing raw RGBG Bayer sensor data. This is primarily for subclasses and typing. Do not instantiate this class manually.
+        """
+
+        self.bayer_data_scaled  : np.ndarray = None
+        self.wb_coeff           : np.ndarray = None
+        self.mat_xyz            : np.ndarray = None
+        self.current_ev         : float      = np.inf
+        self.lim_sat            : float      = 1.0
+        self.__is_hdr           : bool       = False
+
+    def set_hdr(self, is_hdr : bool):
+        """Set whether the image should be treated as HDR or not.
+
+        Args:
+            is_hdr (bool): HDR flag.
+        """
+        self.__is_hdr = is_hdr
+    
+    def get_hdr(self) -> bool:
+        """Get whether the image is HDR or not.
+
+        Returns:
+            bool: True if HDR.
+        """
+        # TODO - Return True if any part of bayer_data_scaled is greater than 1. 
+        return self.__is_hdr
+    
+    def is_valid(self) -> bool:
+        """Check if contents of this image are valid, i.e., are expected.
+
+        Returns:
+            bool: True if image is valid; False otherwise.
+        """
+        return type(self.bayer_data_scaled) != type(None) and type(self.wb_coeff) != type(None) and type(self.mat_xyz) != type(None) and self.current_ev != np.inf
+
+    def debayer(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> Optional[RawDebayerData]:
+        """Debayer this image. Override this method. This is intentionally unimplemented for the base class.
+
+        Args:
+            quality (QualityDemosaic): Quality. Affects debayering algorithm; currently only shifting is supported which is fast but low quality.
+            postprocess_steps (int, optional): Amount of divergence correction steps. Lower values retain detail but leave artifacts. Ignored unless using Best quality. Defaults to 1.
+
+        Returns:
+            Optional[RawDebayerData]: Base class always returns None.
+        """
+
+        return None

--- a/debayer.py
+++ b/debayer.py
@@ -1,0 +1,203 @@
+from typing import Optional
+
+import cv2
+import numpy as np
+from numba import njit
+
+from .bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
+from .colorize import cam_to_lin_srgb
+from .image import RawDebayerData, RawRgbgData
+
+def debayer_ahd(image : RawRgbgData, deartifact : bool = True, postprocess : bool = True) -> Optional[RawDebayerData]:
+    """Debayer using the Adaptive Homogeneity-Directed Demosaicing algorithm by Hirakawa and Parks (2005).
+
+    This is slow but produces high-quality results with reduced zippering and smooth graduation.
+    
+    This works by using recreating the green channel for red and blue in two directions and using a
+    smoothness metric to pick the resulting direction that produces the least artifacts.
+
+    Args:
+        image (RawRgbgData): Bayer image with RGBG pattern.
+        deartifact (bool, optional): Restrict interpolation to within surrounding channels. Defaults to True.
+        postprocess (bool, optional): Reduce color bleeding. Defaults to True.
+
+    Returns:
+        Optional[RawDebayerData]: Debayered image; None if image is not valid.
+    """
+
+    def build_homogeneity_map(r : np.ndarray, g : np.ndarray, b : np.ndarray, is_vertical : bool, domain_k : int = 5) -> np.ndarray:
+
+        # Domain ball neighborhood - pixels within d distance of x
+        # Level neighborhood - pixels within epsilon brightness of x
+        # Color neighborhood - pixels within epsilon color of x
+        # Metric neighborhood - Intersection of all
+        # Homogeneity = Len(metric neighborhood) / Len(domain)
+
+        @njit(inline = "always")
+        def get_color_plane_diff_squared(a_lab : np.ndarray, b_lab : np.ndarray) -> float:
+            diff_a = (a_lab[1] - b_lab[1]) ** 2
+            diff_b = (a_lab[2] - b_lab[2]) ** 2
+            return diff_a + diff_b
+        
+        @njit(inline = "always")
+        def get_color_plane_diff_array_squared(array_lab : np.ndarray, b_lab : np.ndarray) -> np.ndarray:
+            diff_a = (array_lab[:,:,1] - b_lab[1]) ** 2
+            diff_b = (array_lab[:,:,2] - b_lab[2]) ** 2
+            return diff_a + diff_b
+
+        assert domain_k % 2 == 1
+
+        k_pad = domain_k // 2
+        len_domain = domain_k ** 2
+
+        # Use camera matrix to convert internal to CIELAB
+        # TODO - Can just use XYZ values directly
+        # TODO - Don't know what OpenCV is doing to these values. Colorspace? Gamma correction?
+        im_rgb = cam_to_lin_srgb(np.dstack((r * image.wb_coeff[0],
+                                            g * image.wb_coeff[1],
+                                            b * image.wb_coeff[2])), image.mat_xyz, clip_highlights=False)
+
+        lab = cv2.cvtColor(im_rgb, cv2.COLOR_RGB2LAB)
+        lab = cv2.copyMakeBorder(lab, k_pad, k_pad, k_pad, k_pad, cv2.BORDER_REFLECT)
+        
+        @njit
+        def build_map() -> np.ndarray:
+            homogeneity = np.zeros((r.shape[0], r.shape[1]), np.float32)
+
+            for y in range(r.shape[0]):
+                s_y = y + k_pad
+                for x in range(r.shape[1]):
+                    s_x = x + k_pad
+
+                    ref = lab[s_y,s_x]
+
+                    if is_vertical:
+                        epsi_l = max(np.abs(ref[0] - lab[s_y - 1,s_x,0]),
+                                    np.abs(ref[0] - lab[s_y + 1,s_x,0]))
+                        epsi_c_2 = max(get_color_plane_diff_squared(ref, lab[s_y - 1,s_x]),
+                                    get_color_plane_diff_squared(ref, lab[s_y + 1,s_x]))
+                    else:
+                        epsi_l = max(np.abs(ref[0] - lab[s_y,s_x - 1,0]),
+                                    np.abs(ref[0] - lab[s_y,s_x + 1,0]))
+                        epsi_c_2 = max(get_color_plane_diff_squared(ref, lab[s_y,s_x - 1]),
+                                    get_color_plane_diff_squared(ref, lab[s_y,s_x + 1]))
+
+                    window = lab[y:y + domain_k, x:x + domain_k]
+                    delta_l = np.abs(window[:,:,0] - ref[0]) <= epsi_l
+                    delta_c_2 = get_color_plane_diff_array_squared(window, ref) <= epsi_c_2
+
+                    deltas = np.logical_and(delta_l, delta_c_2)
+                    homogeneity[y,x] = np.sum(deltas)
+            
+            return homogeneity
+
+        homogeneity = build_map()
+        homogeneity /= len_domain
+        return homogeneity
+
+    if not(image.is_valid()):
+        return None
+
+    r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
+
+    # Pad photosites to make wrapping a bit easier
+    #     Interpolation needs the photosites at edges as well as current, so we need to pad to let this work for edge pixels
+    r = cv2.copyMakeBorder(r, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+    g1 = cv2.copyMakeBorder(g1, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+    b = cv2.copyMakeBorder(b, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+    g2 = cv2.copyMakeBorder(g2, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+
+    # Blend h, h_optimal is the optimal solution presented in paper. Produces no mazes but leaves aliased crosses instead
+    #     h_fast is their power-of-two version. Smoother appearance but produces mazes
+    # Blending them can improve the naturalness a bit
+    h_optimal   = np.array([-0.2569, 0.4339, 0.5138, 0.4339, -0.2569])
+    h_fast      = np.array([-0.25, 0.5, 0.5, 0.5, -0.25])
+    ratio_optimal = 0.75
+    h = (h_optimal * ratio_optimal) + (h_fast * (1 - ratio_optimal))
+
+    # Artifacts can be created from hot pixel removal, this can reduce the appearance of them
+    def deartifact(chan : np.ndarray, lim_chan_0 : np.ndarray, lim_chan_1 : np.ndarray) -> np.ndarray:
+        # TODO - Try median
+        if deartifact:
+            stacked = np.dstack((lim_chan_0, lim_chan_1))
+            min_chan = np.min(stacked, axis=2)
+            max_chan = np.max(stacked, axis=2)
+            average = (min_chan + max_chan) / 2
+            return np.where(np.logical_or(chan < min_chan, chan > max_chan), average, chan)
+        
+        return chan
+
+    # Interpolate green channel from red
+    gh_r = (r[1:-1, :-2] * h[0]) + (g1[1:-1, :-2] * h[1]) + (r[1:-1, 1:-1] * h[2]) + (g1[1:-1, 1:-1] * h[3]) + (r[1:-1, 2:] * h[4])
+    gv_r = (r[:-2, 1:-1] * h[0]) + (g2[:-2, 1:-1] * h[1]) + (r[1:-1, 1:-1] * h[2]) + (g2[1:-1, 1:-1] * h[3]) + (r[2:, 1:-1] * h[4])
+
+    # Interpolate green channel from blue
+    gh_b = (b[1:-1, :-2] * h[0]) + (g2[1:-1, 1:-1] * h[1]) + (b[1:-1, 1:-1] * h[2]) + (g2[1:-1, 2:] * h[3]) + (b[1:-1, 2:] * h[4])
+    gv_b = (b[:-2, 1:-1] * h[0]) + (g1[1:-1, 1:-1] * h[1]) + (b[1:-1, 1:-1] * h[2]) + (g1[2:, 1:-1] * h[3]) + (b[2:, 1:-1] * h[4])
+
+    gh_r = deartifact(gh_r, g1[1:-1, :-2], g1[1:-1, 1:-1])
+    gv_r = deartifact(gv_r, g2[:-2, 1:-1], g2[1:-1, 1:-1])
+    gh_b = deartifact(gh_b, g2[1:-1, 1:-1], g2[1:-1, 2:])
+    gv_b = deartifact(gv_b, g1[1:-1, 1:-1], g1[2:, 1:-1])
+
+    # Reconstruct full resolution green channels
+    g_h = rgbg_to_bayer(gh_r, g1[1:-1, 1:-1], gh_b, g2[1:-1, 1:-1])
+    g_v = rgbg_to_bayer(gv_r, g1[1:-1, 1:-1], gv_b, g2[1:-1, 1:-1])
+
+    # Reconstruct full resolution other channels
+    r_h = cv2.pyrUp(r[1:-1, 1:-1] - gh_r) + g_h
+    r_v = cv2.pyrUp(r[1:-1, 1:-1] - gv_r) + g_v
+    b_h = cv2.pyrUp(b[1:-1, 1:-1] - gh_b) + g_h
+    b_v = cv2.pyrUp(b[1:-1, 1:-1] - gv_b) + g_v
+    
+    print("Building homogeneity map (horizontal)...")
+    map_h = build_homogeneity_map(r_h, b_h, g_h, False)
+
+    print("Building homogeneity map (vertical)...")
+    map_v = build_homogeneity_map(r_v, b_v, g_v, True)
+
+    rgb_h = np.dstack((r_h, g_h, b_h))
+    rgb_v = np.dstack((r_v, g_v, b_v))
+
+    # Blur the homogeneity maps to consider wider homogeneity when merging
+    map_h = cv2.blur(map_h, (3,3))
+    map_v = cv2.blur(map_v, (3,3))
+
+    combination = (map_h < map_v).astype(np.float32)
+    combination = np.reshape(combination, (combination.shape[0], combination.shape[1], 1))
+
+    rgb_h *= combination
+    rgb_v *= (1 - combination)
+
+    def postprocess_color(image_prev : np.ndarray) -> np.ndarray:
+
+        def median(im : np.ndarray) -> np.ndarray:
+            return cv2.medianBlur(im, 5)    # Small median results in extreme sharpening and overshoot, use 3 or higher to eliminate overshoot
+
+        image_next = np.copy(image_prev)
+        r = image_next[:,:,0]
+        g = image_next[:,:,1]
+        b = image_next[:,:,2]
+
+        r = median(r - g) + g
+        b = median(b - g) + g
+        g = (median(g - r) + median(g - b) + r + b) / 2
+        return np.dstack((r,g,b))
+
+    # 3 iterations of postprocessing
+    debayered = rgb_h + rgb_v
+
+    # White balance prior to postprocessing to reduce highlight shifting
+    debayered[:,:,0] = debayered[:,:,0] * image.wb_coeff[0]
+    debayered[:,:,1] = debayered[:,:,1] * image.wb_coeff[1]
+    debayered[:,:,2] = debayered[:,:,2] * image.wb_coeff[2]
+
+    if postprocess:
+        debayered = postprocess_color(debayered)
+        debayered = postprocess_color(debayered)
+        debayered = postprocess_color(debayered)
+
+    debayered = RawDebayerData(debayered, np.copy(image.wb_coeff), wb_norm=False)
+    debayered.mat_xyz = np.copy(image.mat_xyz)
+    debayered.current_ev = image.current_ev
+    return debayered

--- a/debayer/__init__.py
+++ b/debayer/__init__.py
@@ -1,0 +1,2 @@
+from .ahd import debayer as debayer_ahd
+from .fast_resize import debayer as debayer_fast

--- a/debayer/ahd.py
+++ b/debayer/ahd.py
@@ -6,9 +6,9 @@ import numpy as np
 from .ahd_homogeneity_cython import build_map
 from ..bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from ..colorize import cam_to_lin_srgb
-from ..image import RawDebayerData, RawRgbgData, HdrRgbgData
+from ..base_types.image_base import RawRgbgData_BaseType, RawDebayerData
 
-def debayer(image : Union[RawRgbgData, HdrRgbgData], deartifact : bool = True, postprocess_stages : int = 1) -> Optional[RawDebayerData]:
+def debayer(image : Union[RawRgbgData_BaseType], deartifact : bool = True, postprocess_stages : int = 1) -> Optional[RawDebayerData]:
     """Debayer using the Adaptive Homogeneity-Directed Demosaicing algorithm by Hirakawa and Parks (2005).
 
     This is slow but produces high-quality results with reduced zippering and smooth graduation.
@@ -19,7 +19,7 @@ def debayer(image : Union[RawRgbgData, HdrRgbgData], deartifact : bool = True, p
     If a HDR image is provided, internal tonemapping will be performed while reducing zipper artifacts.
 
     Args:
-        image (Union[RawRgbgData, HdrRgbgData]): Bayer image with RGBG pattern.
+        image (RawRgbgData_BaseType): Bayer image with RGBG pattern.
         deartifact (bool, optional): Restrict interpolation to within surrounding channels. Defaults to True.
         postprocess (bool, optional): Reduce color bleeding. Defaults to True.
 
@@ -44,7 +44,7 @@ def debayer(image : Union[RawRgbgData, HdrRgbgData], deartifact : bool = True, p
                                             g * image.wb_coeff[1],
                                             b * image.wb_coeff[2])), image.mat_xyz, clip_highlights=False)
         
-        if isinstance(image, HdrRgbgData):
+        if image.get_hdr():
             # If the image is HDR, we can't formulate a CIELAB representation
             # Instead, use luma for L* and tonemap to get A*B*.
             luma = 0.2126 * im_rgb[:,:,0] + 0.7152 * im_rgb[:,:,1] + 0.0722 * im_rgb[:,:,2]

--- a/debayer/ahd.py
+++ b/debayer/ahd.py
@@ -1,0 +1,156 @@
+from typing import Optional
+
+import cv2
+import numpy as np
+
+from .ahd_homogeneity_cython import build_map
+from ..bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
+from ..colorize import cam_to_lin_srgb
+from ..image import RawDebayerData, RawRgbgData
+
+def debayer(image : RawRgbgData, deartifact : bool = True, postprocess : bool = True) -> Optional[RawDebayerData]:
+    """Debayer using the Adaptive Homogeneity-Directed Demosaicing algorithm by Hirakawa and Parks (2005).
+
+    This is slow but produces high-quality results with reduced zippering and smooth graduation.
+    
+    This works by using recreating the green channel for red and blue in two directions and using a
+    smoothness metric to pick the resulting direction that produces the least artifacts.
+
+    Args:
+        image (RawRgbgData): Bayer image with RGBG pattern.
+        deartifact (bool, optional): Restrict interpolation to within surrounding channels. Defaults to True.
+        postprocess (bool, optional): Reduce color bleeding. Defaults to True.
+
+    Returns:
+        Optional[RawDebayerData]: Debayered image; None if image is not valid.
+    """
+
+    def build_homogeneity_map(r : np.ndarray, g : np.ndarray, b : np.ndarray, is_vertical : bool, domain_k : int = 5) -> np.ndarray:
+
+        # Domain ball neighborhood - pixels within d distance of x
+        # Level neighborhood - pixels within epsilon brightness of x
+        # Color neighborhood - pixels within epsilon color of x
+        # Metric neighborhood - Intersection of all
+        # Homogeneity = Len(metric neighborhood) / Len(domain)
+        assert domain_k % 2 == 1
+        k_pad = domain_k // 2
+
+        # Use camera matrix to convert internal to CIELAB
+        # TODO - Can just use XYZ values directly
+        # TODO - Don't know what OpenCV is doing to these values. Colorspace? Gamma correction?
+        im_rgb = cam_to_lin_srgb(np.dstack((r * image.wb_coeff[0],
+                                            g * image.wb_coeff[1],
+                                            b * image.wb_coeff[2])), image.mat_xyz, clip_highlights=False)
+
+        lab = cv2.cvtColor(im_rgb, cv2.COLOR_RGB2LAB)
+        lab = cv2.copyMakeBorder(lab, k_pad, k_pad, k_pad, k_pad, cv2.BORDER_REFLECT)
+        
+        homogeneity = build_map(lab, k_pad, domain_k, is_vertical)
+        return homogeneity
+
+    if not(image.is_valid()):
+        return None
+
+    r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
+
+    # Pad photosites to make wrapping a bit easier
+    #     Interpolation needs the photosites at edges as well as current, so we need to pad to let this work for edge pixels
+    r = cv2.copyMakeBorder(r, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+    g1 = cv2.copyMakeBorder(g1, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+    b = cv2.copyMakeBorder(b, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+    g2 = cv2.copyMakeBorder(g2, 1, 1, 1, 1, cv2.BORDER_REFLECT)
+
+    # Blend h, h_optimal is the optimal solution presented in paper. Produces no mazes but leaves aliased crosses instead
+    #     h_fast is their power-of-two version. Smoother appearance but produces mazes
+    # Blending them can improve the naturalness a bit
+    h_optimal   = np.array([-0.2569, 0.4339, 0.5138, 0.4339, -0.2569])
+    h_fast      = np.array([-0.25, 0.5, 0.5, 0.5, -0.25])
+    ratio_optimal = 0.875
+    h = (h_optimal * ratio_optimal) + (h_fast * (1 - ratio_optimal))
+
+    # Artifacts can be created from hot pixel removal, this can reduce the appearance of them
+    def deartifact(chan : np.ndarray, lim_chan_0 : np.ndarray, lim_chan_1 : np.ndarray) -> np.ndarray:
+        # TODO - Try median
+        if deartifact:
+            stacked = np.dstack((lim_chan_0, lim_chan_1))
+            min_chan = np.min(stacked, axis=2)
+            max_chan = np.max(stacked, axis=2)
+            average = (min_chan + max_chan) / 2
+            return np.where(np.logical_or(chan < min_chan, chan > max_chan), average, chan)
+        
+        return chan
+
+    # Interpolate green channel from red
+    gh_r = (r[1:-1, :-2] * h[0]) + (g1[1:-1, :-2] * h[1]) + (r[1:-1, 1:-1] * h[2]) + (g1[1:-1, 1:-1] * h[3]) + (r[1:-1, 2:] * h[4])
+    gv_r = (r[:-2, 1:-1] * h[0]) + (g2[:-2, 1:-1] * h[1]) + (r[1:-1, 1:-1] * h[2]) + (g2[1:-1, 1:-1] * h[3]) + (r[2:, 1:-1] * h[4])
+
+    # Interpolate green channel from blue
+    gh_b = (b[1:-1, :-2] * h[0]) + (g2[1:-1, 1:-1] * h[1]) + (b[1:-1, 1:-1] * h[2]) + (g2[1:-1, 2:] * h[3]) + (b[1:-1, 2:] * h[4])
+    gv_b = (b[:-2, 1:-1] * h[0]) + (g1[1:-1, 1:-1] * h[1]) + (b[1:-1, 1:-1] * h[2]) + (g1[2:, 1:-1] * h[3]) + (b[2:, 1:-1] * h[4])
+
+    gh_r = deartifact(gh_r, g1[1:-1, :-2], g1[1:-1, 1:-1])
+    gv_r = deartifact(gv_r, g2[:-2, 1:-1], g2[1:-1, 1:-1])
+    gh_b = deartifact(gh_b, g2[1:-1, 1:-1], g2[1:-1, 2:])
+    gv_b = deartifact(gv_b, g1[1:-1, 1:-1], g1[2:, 1:-1])
+
+    # Reconstruct full resolution green channels
+    g_h = rgbg_to_bayer(gh_r, g1[1:-1, 1:-1], gh_b, g2[1:-1, 1:-1])
+    g_v = rgbg_to_bayer(gv_r, g1[1:-1, 1:-1], gv_b, g2[1:-1, 1:-1])
+
+    # Reconstruct full resolution other channels
+    r_h = cv2.pyrUp(r[1:-1, 1:-1] - gh_r) + g_h
+    r_v = cv2.pyrUp(r[1:-1, 1:-1] - gv_r) + g_v
+    b_h = cv2.pyrUp(b[1:-1, 1:-1] - gh_b) + g_h
+    b_v = cv2.pyrUp(b[1:-1, 1:-1] - gv_b) + g_v
+    
+    print("Building homogeneity map (horizontal)...")
+    map_h = build_homogeneity_map(r_h, b_h, g_h, False)
+
+    print("Building homogeneity map (vertical)...")
+    map_v = build_homogeneity_map(r_v, b_v, g_v, True)
+
+    rgb_h = np.dstack((r_h, g_h, b_h))
+    rgb_v = np.dstack((r_v, g_v, b_v))
+
+    # Blur the homogeneity maps to consider wider homogeneity when merging
+    map_h = cv2.blur(map_h, (3,3))
+    map_v = cv2.blur(map_v, (3,3))
+
+    combination = (map_h < map_v).astype(np.float32)
+    combination = np.reshape(combination, (combination.shape[0], combination.shape[1], 1))
+
+    rgb_h *= combination
+    rgb_v *= (1 - combination)
+
+    def postprocess_color(image_prev : np.ndarray) -> np.ndarray:
+
+        def median(im : np.ndarray) -> np.ndarray:
+            return cv2.medianBlur(im, 5)    # Small median results in extreme sharpening and overshoot, use 3 or higher to eliminate overshoot
+
+        image_next = np.copy(image_prev)
+        r = image_next[:,:,0]
+        g = image_next[:,:,1]
+        b = image_next[:,:,2]
+
+        r = median(r - g) + g
+        b = median(b - g) + g
+        g = (median(g - r) + median(g - b) + r + b) / 2
+        return np.dstack((r,g,b))
+
+    # 3 iterations of postprocessing
+    debayered = rgb_h + rgb_v
+
+    # White balance prior to postprocessing to reduce highlight shifting
+    debayered[:,:,0] = debayered[:,:,0] * image.wb_coeff[0]
+    debayered[:,:,1] = debayered[:,:,1] * image.wb_coeff[1]
+    debayered[:,:,2] = debayered[:,:,2] * image.wb_coeff[2]
+
+    if postprocess:
+        debayered = postprocess_color(debayered)
+        debayered = postprocess_color(debayered)
+        debayered = postprocess_color(debayered)
+
+    debayered = RawDebayerData(debayered, np.copy(image.wb_coeff), wb_norm=False)
+    debayered.mat_xyz = np.copy(image.mat_xyz)
+    debayered.current_ev = image.current_ev
+    return debayered

--- a/debayer/ahd_homogeneity_cython.pyx
+++ b/debayer/ahd_homogeneity_cython.pyx
@@ -1,0 +1,77 @@
+import numpy as np
+cimport numpy as np
+
+import cython
+cimport cython
+
+from cpython cimport bool
+from cython.parallel import prange, parallel
+from libcpp cimport bool as bool_c
+np.import_array()
+
+DTYPE = np.float32
+ctypedef np.float32_t DTYPE_t
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef float get_diff_square(float a_x, float a_y, float b_x, float b_y) noexcept nogil:
+    return (a_x - b_x) ** 2 + (a_y - b_y) ** 2
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void compute_map(DTYPE_t[:,:,:] lab, DTYPE_t[:,:] output, int r_x, int r_y, int k_pad, bint is_vertical) noexcept nogil:
+    
+    cdef int s_y
+    cdef int s_x
+    cdef int domain_k = k_pad * 2 + 1
+
+    cdef float ref_l
+    cdef float ref_a
+    cdef float ref_b
+
+    cdef float epsi_l
+    cdef float epsi_c_2
+
+    cdef int x, y, w_x, w_y
+    
+    with parallel():
+        for x in prange(r_x):
+            s_x = x + k_pad
+            
+            for y in prange(r_y):
+                s_y = y + k_pad
+
+                # Get target pixel in LAB space
+                ref_l = lab[s_y,s_x,0]
+                ref_a = lab[s_y,s_x,1]
+                ref_b = lab[s_y,s_x,2]
+
+                # Compute bounds
+                if is_vertical:
+                    epsi_l = max(abs(ref_l - lab[s_y - 1,s_x,0]),
+                                    abs(ref_l - lab[s_y + 1,s_x,0]))
+                    epsi_c_2 = max(get_diff_square(ref_a, ref_b, lab[s_y - 1,s_x][1], lab[s_y - 1,s_x][2]),
+                                    get_diff_square(ref_a, ref_b, lab[s_y + 1,s_x][1], lab[s_y + 1,s_x][2]))
+                else:
+                    epsi_l = max(abs(ref_l - lab[s_y,s_x - 1,0]),
+                                    abs(ref_l - lab[s_y,s_x + 1,0]))
+                    epsi_c_2 = max(get_diff_square(ref_a, ref_b, lab[s_y,s_x - 1][1], lab[s_y,s_x - 1][2]),
+                                    get_diff_square(ref_a, ref_b, lab[s_y,s_x + 1][1], lab[s_y,s_x + 1][2]))
+
+                # Get domain window
+                for w_x in prange(x, x + domain_k):
+                    for w_y in prange(y, y + domain_k):
+                        if lab[w_y, w_x, 0] - ref_l <= epsi_l:
+                            if ((lab[w_y, w_x, 1] - ref_a) ** 2 + (lab[w_y, w_x, 2] - ref_b) ** 2) <= epsi_c_2:
+                                output[y,x] = output[y,x] + 1
+
+
+cpdef np.ndarray[DTYPE_t, ndim=2] build_map(np.ndarray[DTYPE_t, ndim=3] lab, unsigned int k_pad, unsigned int domain_k, bool is_vertical):
+    
+    cdef int r_x = lab.shape[1] - k_pad - k_pad
+    cdef int r_y = lab.shape[0] - k_pad - k_pad
+    cdef np.ndarray[DTYPE_t, ndim=2] homogeneity
+    homogeneity = np.zeros([r_y, r_x], dtype=DTYPE)
+
+    compute_map(lab, homogeneity, r_x, r_y, k_pad, is_vertical)
+    return homogeneity

--- a/debayer/fast_resize.py
+++ b/debayer/fast_resize.py
@@ -1,0 +1,38 @@
+from typing import Optional, Union
+
+import cv2
+import numpy as np
+
+from pySP.bayer_chan_mixer import bayer_to_rgbg
+from pySP.base_types.image_base import RawDebayerData, RawRgbgData_BaseType
+
+def debayer(image : RawRgbgData_BaseType) -> Optional[RawDebayerData]:
+    """Debayer by resizing channels to fit original resolution.
+
+    This is fast but produces low-quality results. Divergence is left uncorrected.
+
+    Args:
+        image (RawRgbgData_BaseType): Bayer image with RGBG pattern.
+
+    Returns:
+        Optional[RawDebayerData]: Debayered image; None if image is not valid.
+    """
+
+    if not(image.is_valid()):
+        return None
+    
+    r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
+
+    def debayer_nearest() -> np.ndarray:
+        rgb = np.zeros((r.shape[0], r.shape[1], 3), dtype=np.float32)
+
+        rgb[:,:,0] = r * image.wb_coeff[0]
+        rgb[:,:,1] = ((g1 + g2) / 2) * image.wb_coeff[1]
+        rgb[:,:,2] = b * image.wb_coeff[2]
+
+        return cv2.resize(rgb, (image.bayer_data_scaled.shape[1], image.bayer_data_scaled.shape[0]))
+
+    output = RawDebayerData(debayer_nearest(), np.copy(image.wb_coeff), wb_norm=False)
+    output.mat_xyz = np.copy(image.mat_xyz)
+    output.current_ev = image.current_ev
+    return output

--- a/image.py
+++ b/image.py
@@ -154,6 +154,10 @@ class RawRgbgDataFromRaw(RawRgbgData):
     def is_valid(self) -> bool:
         return self.__is_valid
 
+class HdrRgbgData(RawRgbgData):
+    def __init__(self):
+        super().__init__()
+
 class RawDebayerData():
     def __init__(self, image : np.ndarray, wb_coeff : np.ndarray, wb_norm : bool = False):
         """Class for storing RGB pixel data after debayering.

--- a/image.py
+++ b/image.py
@@ -3,8 +3,9 @@ import numpy as np
 import exifread, rawpy
 from typing import Optional, Union
 from .normalization import bayer_normalize
-from .bayer_chan_mixer import bayer_to_rgbg
-import cv2
+from .debayer import debayer_ahd, debayer_fast
+from .base_types.image_base import RawRgbgData_BaseType, RawDebayerData
+
 from .const import QualityDemosaic
 from math import log
 from io import BytesIO
@@ -67,55 +68,29 @@ def compute_ev_from_exif(filename_or_data : Union[str, bytes]) -> float:
 
     return compute_ev(iso, exp_time, f_stop)
 
-class RawRgbgData():
+class RawRgbgData(RawRgbgData_BaseType):
     def __init__(self):
         """Base class for storing raw RGBG Bayer sensor data.
         """
+        super().__init__()
 
-        self.bayer_data_scaled  : np.ndarray = None
-        self.wb_coeff           : np.ndarray = None
-        self.mat_xyz            : np.ndarray = None
-        self.current_ev         : float      = np.inf
-        self.lim_sat            : float      = 1.0
-    
-    def is_valid(self) -> bool:
-        """Check if contents of this image are valid, i.e., are expected.
-
-        Returns:
-            bool: True if image is valid; False otherwise.
-        """
-        return type(self.bayer_data_scaled) != type(None) and type(self.wb_coeff) != type(None) and type(self.mat_xyz) != type(None) and self.current_ev != np.inf
-
-    def debayer(self, quality : QualityDemosaic) -> Optional[RawDebayerData]:
+    def debayer(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> Optional[RawDebayerData]:
         """Debayers (demosaics) this image to a new RawDebayerData object.
 
         This does not modify the original data in any way. All image properties are copied to the new image.
 
         Args:
             quality (QualityDemosaic): Quality. Affects debayering algorithm; currently only shifting is supported which is fast but low quality.
+            postprocess_steps (int, optional): Amount of divergence correction steps. Lower values retain detail but leave artifacts. Ignored unless using Best quality. Defaults to 1.
 
         Returns:
             Optional[RawDebayerData]: Debayered image; None if this image is not valid.
         """
 
-        if not(self.is_valid()):
-            return None
-
-        r, g1, b, g2 = bayer_to_rgbg(self.bayer_data_scaled)
-
-        def debayer_nearest() -> np.ndarray:
-            rgb = np.zeros((r.shape[0], r.shape[1], 3), dtype=np.float32)
-
-            rgb[:,:,0] = r * self.wb_coeff[0]
-            rgb[:,:,1] = ((g1 + g2) / 2) * self.wb_coeff[1]
-            rgb[:,:,2] = b * self.wb_coeff[2]
-
-            return cv2.resize(rgb, (self.bayer_data_scaled.shape[1], self.bayer_data_scaled.shape[0]))
-
-        output = RawDebayerData(debayer_nearest(), np.copy(self.wb_coeff), wb_norm=False)
-        output.mat_xyz = np.copy(self.mat_xyz)
-        output.current_ev = self.current_ev
-        return output
+        if quality == QualityDemosaic.Best:
+            return debayer_ahd(self, postprocess_stages=postprocess_steps)
+        else:
+            return debayer_fast(self)
 
 class RawRgbgDataFromRaw(RawRgbgData):
     def __init__(self, filename_or_data : Union[str, bytes]):
@@ -153,53 +128,6 @@ class RawRgbgDataFromRaw(RawRgbgData):
     
     def is_valid(self) -> bool:
         return self.__is_valid
-
-class HdrRgbgData(RawRgbgData):
-    def __init__(self):
-        super().__init__()
-
-class RawDebayerData():
-    def __init__(self, image : np.ndarray, wb_coeff : np.ndarray, wb_norm : bool = False):
-        """Class for storing RGB pixel data after debayering.
-
-        Args:
-            image (np.ndarray): RGB pixel data in shape (height, width, 3). Should be normalized and with colors in camera-space after applying white balance correction.
-            wb_coeff (np.ndarray): White balance co-efficients. Should have minimum length of 3.
-            wb_norm (bool, optional): Optional flag to set whether white-balanced was applied in normalizing or naive way. Defaults to False, meaning naive application (multiplied through).
-        """
-
-        self.image              : np.ndarray = image
-        self._wb_coeff         : np.ndarray = wb_coeff
-        self._wb_applied       : bool = True
-        self._wb_normalized    : bool = wb_norm
-        
-        self.mat_xyz            : np.ndarray = None
-        self.current_ev         : float = np.inf
-        
-    def is_valid(self) -> bool:
-        """Check if contents of this image are valid, i.e., are expected.
-
-        Returns:
-            bool: True if image is valid; False otherwise.
-        """
-        return type(self.image) != type(None) and type(self._wb_coeff) != type(None) and type(self.mat_xyz) != type(None) and self.current_ev != np.inf
-    
-    def wb_apply(self):
-        """Apply white balance co-efficients if not already applied.
-        """
-        if not(self._wb_applied):
-            self.image = (self.image * self._wb_coeff[:3]).astype(np.float32)
-            self._wb_applied = True
-    
-    def wb_undo(self):
-        """Undo white balance to return to pure camera-space if white balance was applied. Removes normalization in process.
-        """
-        if self._wb_applied:
-            if self._wb_normalized:
-                self.image = self.image * max(self._wb_coeff)
-            self.image = (self.image.astype(np.float64) / self._wb_coeff[:3]).astype(np.float32)
-            self._wb_applied = False
-            self._wb_normalized = False
 
 class RawDebayerDataFromRaw(RawDebayerData):
     def __init__(self, filename_or_data : Union[str, bytes]):

--- a/raw_hdr.py
+++ b/raw_hdr.py
@@ -1,4 +1,4 @@
-from .image import HdrRgbgData, RawRgbgData, RawDebayerData
+from .image import RawRgbgData, RawDebayerData
 from .colorize import cam_to_lin_srgb
 import numpy as np
 from typing import Tuple, List, Optional
@@ -81,7 +81,7 @@ def fuse_exposures_from_debayer(in_exposures : List[RawDebayerData], target_ev :
 
     return (sum_pixel, debug_count_references)
 
-def fuse_exposures_to_raw(in_exposures : List[RawRgbgData], target_ev : Optional[float] = None) -> Optional[Tuple[HdrRgbgData, np.ndarray]]:
+def fuse_exposures_to_raw(in_exposures : List[RawRgbgData], target_ev : Optional[float] = None) -> Optional[Tuple[RawRgbgData, np.ndarray]]:
     """Fuse exposures to a new HDR raw image from a list of raw images while preserving the Bayer pattern.
 
     This method operates in sensor-space so is unaffected by response curves or sensor saturation.
@@ -148,11 +148,12 @@ def fuse_exposures_to_raw(in_exposures : List[RawRgbgData], target_ev : Optional
         sum_pixel = np.divide(sum_pixel, sum_weight)
     sum_pixel = np.where(sum_weight == 0, max_exposure, sum_pixel)
 
-    hdr_image = HdrRgbgData()
+    hdr_image = RawRgbgData()
     hdr_image.bayer_data_scaled = sum_pixel
     hdr_image.current_ev = target_ev
     hdr_image.lim_sat = max(ev_offsets)
     hdr_image.mat_xyz = np.copy(valid_exposures[0].mat_xyz)
     hdr_image.wb_coeff = np.copy(valid_exposures[0].wb_coeff)
+    hdr_image.set_hdr(True)
 
     return (hdr_image, debug_count_references)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Cython==3.0.9
 ExifRead==3.0.0
 numpy==1.24.1
 opencv_python==4.9.0.80

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import numpy
 setup(
     ext_modules=cythonize((Extension("debayer.ahd_homogeneity_cython",
                                      sources=["debayer\\ahd_homogeneity_cython.pyx"],
-                                     extra_compile_args=['/openmp', '/Ox'],
-                                     include_dirs=[numpy.get_include()])))
+                                     extra_compile_args=['/openmp:llvm', '/Ox', '/fp:fast'],
+                                     include_dirs=[numpy.get_include()])),
+                          compiler_directives={'language_level' : "3"})
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup, Extension
+from Cython.Build import cythonize
+import numpy
+
+# TODO - Support GCC, this is for MSVC
+
+setup(
+    ext_modules=cythonize((Extension("debayer.ahd_homogeneity_cython",
+                                     sources=["debayer\\ahd_homogeneity_cython.pyx"],
+                                     extra_compile_args=['/openmp', '/Ox'],
+                                     include_dirs=[numpy.get_include()])))
+)


### PR DESCRIPTION
HDR stacking using libraw is sharp but has artifacts (not sure why). Sensor-level stacking has zero artifacts but the current mainline implementation only has low quality demosaicing. AHD is relatively simple, produces sharper images and was widely used until newer algorithms appeared (e.g., AMaZE). This PR adds AHD and extends it for HDR support so now the full HDR imaging pipeline can be completed inside of pySP.