### PR TITLE
Add proper white balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 pySP is a Python-based raw converter that implements parts of a basic image signal processing pipeline.
 
 ## what is pySP for?
-pySP is designed to simplify the less intuitive parts of raw image processing while still letting you interact with sensor data. It's **not a replacement for actual raw converters** but is useful as a first step towards custom imaging pipelines.
+pySP is designed to simplify the less intuitive parts of raw image processing while still letting you interact with sensor data. It's **not a replacement for actual raw converters** but is useful for custom imaging pipelines.
 
 pySP has the following features:
  - Raw bayer value decoding via rawpy (libraw)
@@ -34,43 +34,73 @@ pySP is designed to be used as a submodule. Once cloned and built, it can be imp
 ## how do I use pySP?
 
 ### Converting a raw to an sRGB image
-Raw processing transitions through different colorspaces, some linear and some gamma corrected. Gamma correction is required for images to render as expected but any operations on images should happen inside linear space. The output from debayering is within the camera's own linear space (after white balancing). pySP currently only supports the sRGB colorspace and provides methods to transform from camera space to sRGB for image rendering.
+Raw processing transitions through different colorspaces. It starts at the sensor-level which are the values your camera sees through its filters. It is then debayered, white-balanced and transformed to XYZ where it can be shifted to any other space. pySP currently only supports sRGB and provides simple methods to develop from camera to linear RGB (and sRGB) where it can then be used like a normal image. The first step is debayering of which pySP offers two pathways.
 
-Debayering via pySP uses the following algorithms at each quality setting:
+Debayering via pySP's internal path uses the following algorithms at each quality setting:
 
- - Draft - Use RB as is, average G and bilinear upscale
-	 - Fast but adds no detail and reduces sharpness and leaves fringing
+ - Draft - Align and resample colors to quarter-res at pixel centers, bilinear scale back to original resolution
+     - Fast with little fringing but very soft due to quarter resolution solve
  - Fast - Unimplemented, planned to trade off between Best/Draft
  - Best - Adaptive Homogeneity-Directed Demosaicing algorithm (Hirakawa, K. and Parks, T.W., 2005)
 	 - Sharpens detail well with minimal zippering
 	 - Slower than libraw for performance critical applications but supports HDR
 	 - Implementation is naive and follows paper exactly; fringing is corrected using their color postprocessing method which can inadvertently remove small colored details
-	 -  Postprocessing can be adjusted with the `postprocess_stages` argument
+	 - Postprocessing can be adjusted with the `postprocess_stages` argument
+     - Close match for other software using non-ML techniques
 
 #### Debayering via pySP
     from pySP.const import QualityDemosaic
-    from pySP.colorize import cam_to_lin_srgb, lin_srgb_to_srgb
+    from pySP.colorize import lin_srgb_to_srgb
     from pySP.image import RawRgbgDataFromRaw
     
     PATH_IMAGE_DNG = ...
     
     image = RawRgbgDataFromRaw(PATH_IMAGE_DNG)
-    image_debayered = image.debayer(QualityDemosaic.Best)
-    debayered_linear = cam_to_lin_srgb(image_debayered.image, image_debayered.mat_xyz)
-    debayered_srgb = lin_srgb_to_srgb(debayered_linear)
+    image_debayered_rgb = image.debayer(QualityDemosaic.Best).to_lin_srgb()
+    debayered_srgb = lin_srgb_to_srgb(image_debayered_rgb)
 
-#### Debayering via libraw (slow, different algorithms)
+#### Debayering via libraw (different algorithms, slower by default)
 
-By default, rawpy is configured to apply noise reduction and will produce a slightly different tint to the image. Precision is otherwise the same so this is easy to correct. This method blocks access to raw Bayer data.
+By default, rawpy is configured to apply noise reduction and will produce a slightly different tint to the image. Precision is otherwise the same so this is easy to correct. This method blocks access to raw Bayer data since pySP doesn't aim to replicate libraw's pipeline. Removing noise reduction will make debayering faster than pySP - if you don't require any pySP sensor-level features, use `rawpy` for image processing instead. This only exists as a means for bayer noise reduction in pySP and may be removed in the future.
 
-    from pySP.colorize import cam_to_lin_srgb, lin_srgb_to_srgb
+    from pySP.colorize import lin_srgb_to_srgb
     from pySP.image import RawDebayerDataFromRaw
     
     PATH_IMAGE_DNG = ...
     
-    image_debayered = RawDebayerDataFromRaw(PATH_IMAGE_DNG)
-    debayered_linear = cam_to_lin_srgb(image_debayered.image, image_debayered.mat_xyz)
-    debayered_srgb = lin_srgb_to_srgb(debayered_linear)
+    image_debayered_rgb = RawDebayerDataFromRaw(PATH_IMAGE_DNG).to_lin_srgb()
+    debayered_srgb = lin_srgb_to_srgb(image_debayered_rgb)
+
+### Adjusting White Balance
+**If you're happy with the colors in your image, you probably won't need to touch this.** Most cameras do a good job estimating the scene white.
+
+pySP uses a multiplier-based white balancing system which tries to minimize unnatural color casts under a range of illuminants. It does this by blending pre-calibrated profiles inside the raw files. By default, it uses the camera's estimated illuminant to interpolate a profile which minimizes tint (cast) according to the Planckian locus. If your images contain no defined neutral multipliers or no color calibrations (which is extremely unlikely, especially if it's a DNG), pySP will fail to load your images.
+
+#### Setting white balance from a neutral patch
+
+    from pySP.colorize import lin_srgb_to_srgb
+    from pySP.image import RawRgbgDataFromRaw
+    
+    PATH_IMAGE_DNG = ...
+    
+    image = RawRgbgDataFromRaw(PATH_IMAGE_DNG)
+    image.cam_wb.update_by_reference(CAM_WHITE)
+
+These can be found after debayering where the camera-space values of any neutral patch may be used to update color management for the raw image. Make sure to return to camera-space using `wb_undo()` before reading neutral values from the debayered image. Because debayering is sensitive to color, any adjustments to the neutral point require debayering to be done again to prevent strange tints entering the image.
+
+#### Setting white balance from known temperature
+
+    from pySP.colorize import lin_srgb_to_srgb
+    from pySP.image import RawRgbgDataFromRaw
+    
+    PATH_IMAGE_DNG = ...
+    
+    image = RawRgbgDataFromRaw(PATH_IMAGE_DNG)
+    image.cam_wb.update_by_temperature(ILL_TEMP, duv = ..., override_blend = ...)
+
+When setting white point using temperature, it may be desirable to override blending behaviour to only use the closest camera calibration rather than attempt to interpolate one by setting `override_blend = 0`. Camera calibrations typically include 2 matrices from different series, one for daylight-series illuminants and the other for a standard illuminant. Blending calibrations between different illuminant series can create unnatural tints.
+
+Under the hood pySP uses xyz color for defining illuminants. Temperature alone is insufficient to describe an illuminant so pySP exposes `duv` as a measure of the tint away from the Planckian locus - combining this with temperature gives an exact mapping for the desired illuminant. By default, pySP assumes the desired temperature is close to the daylight series (like other software) so will compute this for you when `duv = None`. There is a discontinuity at 4000K as there are no daylight series illuminants defined under 4000K so we snap back to the locus.
 
 ### Removing hot pixels in raws
 Hot pixel removal works on raw Bayer data so is currently only compatible with pySP's debayering. Removal works in-place so the image can be used like normal after corrections (e.g., can then be debayered).
@@ -116,12 +146,11 @@ Sensor-space stacking works on photosite data so retains the complete dynamic ra
 
 To render this image tonemapping is required. It is recommended that HDR images are exported and tonemapped in other software but a quick solution for debugging can be to use the Reinhardt tonemapper to produce an image that can be viewed correctly.
 
-    from pySP.colorize import cam_to_lin_srgb, lin_srgb_to_srgb
+    from pySP.colorize import lin_srgb_to_srgb
     
     ...
     
-    image_hdr_debayered = image_hdr.debayer(QualityDemosaic.Best)
-    debayered_hdr_linear = cam_to_lin_srgb(image_hdr_debayered.image, image_hdr_debayered.mat_xyz)
+    debayered_hdr_linear = image_hdr.debayer(QualityDemosaic.Best).to_lin_srgb()
 	debayered_ldr = debayered_hdr_linear / (1 + debayered_hdr_linear)
     debayered_ldr_srgb = lin_srgb_to_srgb(debayered_ldr)
 

--- a/base_types/image_base.py
+++ b/base_types/image_base.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from pySP.colorize import cam_to_lin_srgb
 from pySP.const import QualityDemosaic
+from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
 
 class RawDebayerData():
     def __init__(self, image : np.ndarray, wb_coeff : np.ndarray, wb_norm : bool = False):
@@ -19,7 +20,7 @@ class RawDebayerData():
         self._wb_applied        : bool = True
         self._wb_normalized     : bool = wb_norm
         
-        self.mat_xyz            : np.ndarray = None
+        self.mat_xyz            : MatXyzToCamera = None
         self.current_ev         : float = np.inf
         
     def is_valid(self) -> bool:
@@ -28,7 +29,7 @@ class RawDebayerData():
         Returns:
             bool: True if image is valid; False otherwise.
         """
-        return type(self.image) != type(None) and type(self._wb_coeff) != type(None) and type(self.mat_xyz) != type(None) and self.current_ev != np.inf
+        return type(self.image) != type(None) and type(self._wb_coeff) != type(None) and type(self.mat_xyz) != type(MatXyzToCamera) and self.current_ev != np.inf
     
     def wb_apply(self):
         """Apply white balance co-efficients if not already applied.
@@ -58,7 +59,7 @@ class RawRgbgData_BaseType():
 
         self.bayer_data_scaled  : np.ndarray = None
         self.wb_coeff           : np.ndarray = None
-        self.mat_xyz            : np.ndarray = None
+        self.mat_xyz            : MatXyzToCamera = None
         self.current_ev         : float      = np.inf
         self.lim_sat            : float      = 1.0
         self.__is_hdr           : bool       = False

--- a/base_types/image_base.py
+++ b/base_types/image_base.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from pySP.colorize import cam_to_lin_srgb
 from pySP.const import QualityDemosaic
+from pySP.wb_cct.cam_wb import CameraWhiteBalanceController
 from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
 
 class RawDebayerData():
@@ -58,8 +59,7 @@ class RawRgbgData_BaseType():
         """
 
         self.bayer_data_scaled  : np.ndarray = None
-        self.wb_coeff           : np.ndarray = None
-        self.mat_xyz            : MatXyzToCamera = None
+        self.cam_wb             : CameraWhiteBalanceController = None
         self.current_ev         : float      = np.inf
         self.lim_sat            : float      = 1.0
         self.__is_hdr           : bool       = False
@@ -87,7 +87,7 @@ class RawRgbgData_BaseType():
         Returns:
             bool: True if image is valid; False otherwise.
         """
-        return type(self.bayer_data_scaled) != type(None) and type(self.wb_coeff) != type(None) and type(self.mat_xyz) != type(None) and self.current_ev != np.inf
+        return type(self.bayer_data_scaled) != type(None) and type(self.cam_wb) != type(None) and self.current_ev != np.inf
 
     def debayer(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> Optional[RawDebayerData]:
         """Debayer this image. Override this method. This is intentionally unimplemented for the base class.

--- a/debayer/ahd.py
+++ b/debayer/ahd.py
@@ -3,6 +3,8 @@ from typing import Optional, Union
 import cv2
 import numpy as np
 
+from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
+
 from ..base_types.image_base import RawDebayerData, RawRgbgData_BaseType
 from ..bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from ..colorize import cam_to_lin_srgb
@@ -186,6 +188,6 @@ def debayer(image : Union[RawRgbgData_BaseType], deartifact : bool = True, postp
         debayered = postprocess_color(debayered)
 
     debayered = RawDebayerData(debayered, np.copy(image.wb_coeff), wb_norm=False)
-    debayered.mat_xyz = np.copy(image.mat_xyz)
+    debayered.mat_xyz = MatXyzToCamera(image.mat_xyz.mat, image.mat_xyz.xyz)
     debayered.current_ev = image.current_ev
     return debayered

--- a/debayer/fast_resize.py
+++ b/debayer/fast_resize.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from pySP.bayer_chan_mixer import bayer_to_rgbg
 from pySP.base_types.image_base import RawDebayerData, RawRgbgData_BaseType
+from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
 
 def debayer(image : RawRgbgData_BaseType) -> Optional[RawDebayerData]:
     """Debayer by resizing channels to fit original resolution.
@@ -42,6 +43,6 @@ def debayer(image : RawRgbgData_BaseType) -> Optional[RawDebayerData]:
         return cv2.resize(rgb, (image.bayer_data_scaled.shape[1], image.bayer_data_scaled.shape[0]))
 
     output = RawDebayerData(debayer_nearest(), np.copy(image.wb_coeff), wb_norm=False)
-    output.mat_xyz = np.copy(image.mat_xyz)
+    output.mat_xyz = MatXyzToCamera(image.mat_xyz.mat, image.mat_xyz.xyz)
     output.current_ev = image.current_ev
     return output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-Cython==3.0.10
+colour-science==0.4.4
+Cython==3.0.11
 ExifRead==3.0.0
-numpy==1.23.5
-opencv_python==4.8.0.76
-rawpy==0.18.1
+numpy==2.2.4
+opencv_python==4.10.0.84
+rawpy==0.22.0
 tifftools==1.5.2

--- a/wb_cct/__init__.py
+++ b/wb_cct/__init__.py
@@ -1,0 +1,1 @@
+from .cam_wb import get_optimal_camera_mat_from_as_shot, get_optimal_camera_mat_from_cct_duv, get_optimal_camera_mat_from_coords

--- a/wb_cct/__init__.py
+++ b/wb_cct/__init__.py
@@ -1,1 +1,1 @@
-from .cam_wb import get_optimal_camera_mat_from_as_shot, get_optimal_camera_mat_from_cct_duv, get_optimal_camera_mat_from_coords
+from .cam_wb import CameraWhiteBalanceControllerFromExif

--- a/wb_cct/cam_wb.py
+++ b/wb_cct/cam_wb.py
@@ -1,0 +1,214 @@
+import colour
+import numpy as np
+from typing import Dict, Any, Optional, Tuple
+
+from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
+from pySP.wb_cct.helpers_exif import exif_get_as_shot_neutral, exif_get_color_mat_sources
+
+###############################################################################
+#       NOTE - White balancing (at least how I've learnt it works)
+###############################################################################
+# Whites are typically simplified as chromacities that sit close to the
+# Planckian locus. You don't need to fully understand what that is, just that
+# typical reference whites usually sit close to it. I don't get it either!
+#
+#    Cameras use a variety of techniques to figure out what reference value
+# corresponds to white. In this case, we use AsShotNeutral, but this can also
+# be chromacity - the matrices provided (mostly) convert between the two. DNGs
+# provide up to 3 matrices which do this, each calibrated to get optimal color
+# under different illuminants. The shift from using the wrong one isn't too
+# substantial. XYZ is absolute after all so really you are only doing this to
+# minimize tint under the estimated illuminant.
+#
+#    To convert AsShotNeutral to a temperature and get the optimal color
+# matrix, you have to solve for the blending factor between the XYZtoCam
+# matrices that achieves the minimum tint (dUV between output XYZ and closest
+# locus XYZ). Note that the Planckian locus is shifted a bit while solving -
+# temperature alone doesn't map to chromacity. D-series illuminants which
+# are most similar to daylight have a slight tint from the locus which needs
+# to be considered since these tend to look more natural. The output from
+# this is the neutral chromacity and optimal matrix, both of which are
+# needed for adaptation to a fixed reference white later.
+#
+#     Converting temp to camera white balance multipliers is easier.
+# Temp (D-series adjusted) can be transformed to XYZ illuminant, then passed
+# into the camera matrix to get a corresponding AsShotNeutral. The D-series
+# adjustment is required to get values which match other software.
+###############################################################################
+
+# TODO - Typically A and D65 illuminant are supplied with DNG. In most cases,
+#        D65 illuminant is preferred, likely because tint is better aligned
+#        with natural conditions. This is a problem for our temp to neutral
+#        system though because we have to ignore the mired blending suggested
+#        in DNG spec to get same results as other software.
+
+# TODO - Test the matrices this produces
+
+def get_ideal_duv(temperature : float) -> float:
+    """Get a desirable dUV for a given CCT based on the Planckian locus with adjustments after 4000K to D-series illuminants.
+
+    This has a discontinuity at 4000K as D-series ends at D40. Below that is a sharp fall to 0.
+
+    Args:
+        temperature (float): Target color temperature.
+
+    Returns:
+        float: Desirable dUV.
+    """
+    if temperature < 4000:  # D-series illuminants are undefined under 4000K. Switch to blackbody under this
+        return 0    # TODO - Doesn't match other software, still slight tint. This leads to a discontinuity,
+                    #        searching git issues will find reports about this in other software too
+    return colour.temperature.uv_to_CCT_Ohno2013(colour.xy_to_UCS_uv(colour.temperature.CCT_to_xy_CIE_D(temperature)))[1]
+
+def get_optimal_camera_mat_from_as_shot(tags : Dict[str, Any]) -> Optional[Tuple[MatXyzToCamera, float]]:
+    """Interpolate ColorMatrix calibrations to find the optimal matrix under the stored neutral point.
+
+    Args:
+        tags (Dict[str, Any]): Tags dictionary as held by exifread.
+
+    Returns:
+        Optional[Tuple[MatXyzToCamera, float]]: Optimal XYZ to camera matrix (and illuminant). None if no valid ColorMatrix definitions were in the DNG or there is no AsShotNeutral tag.
+    """
+
+    try:
+        multi_cam_wb = exif_get_as_shot_neutral(tags)
+    except:
+        return None
+    
+    return get_optimal_camera_mat_from_coords(tags, multi_cam_wb)
+    
+def get_optimal_camera_mat_from_coords(tags : Dict[str, Any], cam_neutral : np.ndarray, max_iters : int = 30, stop_epsilon : float = 0.000001) -> Optional[MatXyzToCamera]:
+    """Interpolate ColorMatrix calibrations to find the optimal matrix under a provided camera neutral point.
+
+    This algorithm is iterative but for most values will return one of the preset calibrations. It works by finding the matrix that minimizes
+    the tint from an ideal curve assuming neutral is an approximate illuminant. Because daylight illuminants are typically preferred and have
+    a different tinting profile than other illuminants (like A), usually the returned matrix is close to (or exactly) one of the D-series
+    transformation presets.
+
+    Args:
+        tags (Dict[str, Any]): Tags dictionary as held by exifread.
+        cam_neutral (np.ndarray): Camera neutral point in reference (sensor) space [0,1]. Do not normalize to G' = 1.0.
+        max_iters (int, optional): Maximum iterations before stopping. Defaults to 30.
+        stop_epsilon (float, optional): Minimum step size before assumed converged. Defaults to 0.000001.
+
+    Returns:
+        Optional[MatXyzToCamera]: Optimal XYZ to camera matrix (and illuminant). None if no valid ColorMatrix definitions were in the DNG.
+    """
+
+    assert max_iters > 1
+
+    mats = exif_get_color_mat_sources(tags)
+    if len(mats) == 0:
+        return None
+    
+    if len(mats) == 1:
+        return MatXyzToCamera(np.copy(mats[0].mat), np.matmul(np.linalg.inv(mats[0].mat), cam_neutral))
+    
+    mat_k = []
+    for mat in mats:
+        cct_and_tint = colour.temperature.XYZ_to_CCT_Ohno2013(mat.xyz)
+        mat_k.append(cct_and_tint[0])
+    
+    mats = [x for _, x in sorted(zip(mat_k, mats))] # Sort mats by CCT
+    
+    mat_t = [colour.temperature.XYZ_to_CCT_Ohno2013(np.matmul(np.linalg.inv(mat.mat), cam_neutral))[1] for mat in mats]
+    mat_t = [abs(get_ideal_duv(k) - x) for x,k in zip(mat_t, mat_k)]
+
+    idx_lowest = [x for _, x in sorted(zip(mat_t, [y for y in range(len(mats))]))]
+
+    if abs(idx_lowest[0] - idx_lowest[1]) == 1:
+        mat_0 = mats[idx_lowest[0]]
+        mat_1 = mats[idx_lowest[1]]
+    else:
+        mat_0 = mats[idx_lowest[0]]
+        return MatXyzToCamera(np.copy(mat_0.mat), np.matmul(np.linalg.inv(mat_0.mat), cam_neutral))
+
+    # Solve blend factor for minimum error alongside two matrices
+    best_xyz = np.matmul(np.linalg.inv(mat_0.mat), cam_neutral)
+
+    best = min(mat_t)
+    best_bf = 0.0
+    worst_bf = 1.0
+
+    current = float("inf")
+
+    i = 0
+    while i < max_iters and abs(best_bf - worst_bf) > stop_epsilon:
+        current = (worst_bf + best_bf) / 2
+        current_xyz = np.matmul(np.linalg.inv(mat_0.interpolate(mat_1, current)), cam_neutral)
+        cct_and_tint = colour.temperature.XYZ_to_CCT_Ohno2013(current_xyz)
+        tint = abs(get_ideal_duv(cct_and_tint[0]) - cct_and_tint[1])
+        
+        print(current)
+
+        if tint <= best:
+            best = tint
+            best_xyz = current_xyz
+            best_bf = current
+        else:
+            worst_bf = current
+
+        i += 1
+    
+    output = MatXyzToCamera(mat_0.interpolate(mat_1, best_bf), best_xyz)
+
+    print(colour.temperature.XYZ_to_CCT_Ohno2013(best_xyz)[0], best)
+    return output
+
+def get_optimal_camera_mat_from_cct_duv(tags : Dict[str, Any], cct : float, duv : Optional[float] = None, override_blend : Optional[float] = None) -> Optional[Tuple[MatXyzToCamera, np.ndarray]]:
+    """Interpolate ColorMatrix calibrations to find the camera neutral point for a given color temperature.
+
+    Args:
+        tags (Dict[str, Any]): Tags dictionary as held by exifread.
+        cct (float): Target color temperature.
+        duv (Optional[float], optional): Target delta from Planckian locus. Defaults to an idealized curve which leans close to D-series above 4000K and blackbody below. Defaults to None.
+        override_blend (Optional[float], optional): Blend factor override. 0 uses closest CCT, 1 uses furthest. Defaults to None, which blends using mired. Software typically overrides this to use closest.
+
+    Returns:
+        Optional[Tuple[MatXyzToCamera, np.ndarray]]: (CameraMatrix, reference neutral in [1,0]). None if there were no color profiles in the DNG.
+    """
+
+    mats = exif_get_color_mat_sources(tags)
+    if len(mats) == 0:
+        return None
+
+    mat_k = [colour.temperature.XYZ_to_CCT_Ohno2013(mat.xyz)[0] for mat in mats]
+    mats = [x for _, x in sorted(zip(mat_k, mats))]
+    mat_k.sort()
+
+    if duv == None:
+        # Tint is usually computed for a given temperature. This is because we typically imagine temperature as relating
+        #     to D-series illuminants which simulate daylight.
+        # D series is tinted away from the Planckian locus, so compute a tint for the D-series illuminant.
+        # If no illuminant is available, match to Planckian instead.
+
+        duv = get_ideal_duv(cct)
+
+    targ_xyz = colour.temperature.CCT_to_XYZ_Ohno2013(np.array([cct,duv]))
+
+    if cct <= mat_k[0]:
+        return np.matmul(mats[0].mat, targ_xyz)
+    if cct >= mat_k[-1]:
+        return np.matmul(mats[-1].mat, targ_xyz)
+    
+    # Interpolate closest matrices by mired
+    mat_k.append(cct)
+    mat_k.sort()
+
+    idx_0 = mat_k.index(cct) - 1
+    idx_1 = idx_0 + 1
+
+    mat_k.pop(idx_1)
+
+    mat_0 = mats[idx_0]
+    mat_1 = mats[idx_1]
+
+    if override_blend == None:
+        mired_0 = colour.temperature.CCT_to_mired(mat_k[idx_0])
+        mired_1 = colour.temperature.CCT_to_mired(mat_k[idx_1])
+        mired_target = colour.temperature.CCT_to_mired(cct)
+        override_blend = (mired_1 - mired_target) / (mired_1 - mired_0)
+
+    blended_mat = mat_0.interpolate(mat_1, 1 - override_blend)
+
+    return (MatXyzToCamera(blended_mat, targ_xyz), np.matmul(blended_mat, targ_xyz))

--- a/wb_cct/helpers_cam_mat.py
+++ b/wb_cct/helpers_cam_mat.py
@@ -20,7 +20,7 @@ class ChromacityMat():
     def __init__(self, mat : np.ndarray, xyz : np.ndarray):
         self.mat = np.copy(mat)
         self.mat.setflags(write=False)
-        self.xyz = xyz
+        self.xyz = np.copy(xyz)
         self.xyz.setflags(write=False)
         
 class MatXyzToCamera(ChromacityMat):

--- a/wb_cct/helpers_cam_mat.py
+++ b/wb_cct/helpers_cam_mat.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import numpy as np
+
+def bradford_adapt_matrix(current_xyz : np.ndarray, target_xyz : np.ndarray) -> np.ndarray:
+    mat_xyz_to_lms = np.array([[0.8951000, 0.2664000, -0.1614000],
+                               [-0.7502000, 1.7135000, 0.0367000],
+                               [0.0389000, -0.0685000, 1.0296000]])
+
+    lms_curr = np.matmul(mat_xyz_to_lms, current_xyz)
+    lms_targ = np.matmul(mat_xyz_to_lms, target_xyz)
+    lms_scale = lms_targ / lms_curr
+
+    mat_scale = np.array([[lms_scale[0], 0, 0],
+                          [0, lms_scale[1], 0],
+                          [0, 0, lms_scale[2]]])
+    
+    return np.matmul(np.linalg.inv(mat_xyz_to_lms), np.matmul(mat_scale, mat_xyz_to_lms))
+
+class ChromacityMat():
+    def __init__(self, mat : np.ndarray, xyz : np.ndarray):
+        self.mat = np.copy(mat)
+        self.mat.setflags(write=False)
+        self.xyz = xyz
+        self.xyz.setflags(write=False)
+        
+class MatXyzToCamera(ChromacityMat):
+    def interpolate(self, next : MatXyzToCamera, blend : float) -> np.ndarray:
+        blend = np.clip(blend, 0.0, 1.0)
+        mat = self.mat * (1 - blend) + (next.mat * blend)
+        return mat

--- a/wb_cct/helpers_exif.py
+++ b/wb_cct/helpers_exif.py
@@ -1,0 +1,86 @@
+from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
+from pySP.wb_cct.standard_ill import get_chromacity_from_illuminant, get_illuminant_from_lightsource
+from typing import Optional, List, Dict, Any
+from colour import xy_to_XYZ
+import numpy as np
+
+# TODO - !=3 color plane support
+
+def exif_get_color_mat_sources(tags : Dict[str, Any]) -> List[MatXyzToCamera]:
+    """Extract XYZ to reference matrices from EXIF data.
+
+    Args:
+        tags (Dict[str, Any]): Tags dictionary as held by exifread.
+
+    Returns:
+        List[MatXyzToCamera]: List of camera matrices. If length is zero, none could be extracted.
+    """
+
+    # TODO - Support custom illuminant (exifread might not be helpful here)
+
+    def get_mat(idx : int) -> Optional[MatXyzToCamera]:
+        if idx < 0 or idx > 3:
+            return None
+        
+        tag_mat = 0xC621 + idx
+        tag_light = 0xC65A + idx
+        
+        tag_mat = "Image Tag 0x%s" % hex(tag_mat)[2:].upper()
+        tag_light = "Image Tag 0x%s" % hex(tag_light)[2:].upper()
+
+        if not(tag_mat in tags and tag_light in tags):
+            return None
+        
+        try:
+            ill = get_illuminant_from_lightsource(tags[tag_light].values[0])
+            xy = get_chromacity_from_illuminant(ill)
+        except KeyError:
+            return None
+
+        mat = np.zeros((3,3), dtype=np.float32)
+
+        idx = 0
+        for y in range(mat.shape[0]):
+            for x in range(mat.shape[1]):
+                mat[y,x] = tags[tag_mat].values[idx].decimal()
+                idx += 1
+
+        # DNG stores XYZ to camera, we want the other way around
+        return MatXyzToCamera(mat, xy_to_XYZ(xy))
+    
+    output = []
+    id = 0
+    while id < 3:
+        mat = get_mat(id)
+        id += 1
+        
+        if mat == None:
+            break
+        output.append(mat)
+    
+    return output
+
+def exif_get_as_shot_neutral(tags : Dict[str, Any]) -> np.ndarray:
+    """Extract neutral multipliers from EXIF tag. These multipliers are for rough white balancing directly in-camera
+    and have been pre-adjusted to minimize tint. Ideally, multiplying neutral with an appropriate interpolation
+    of the ColorMatrix should result in a value somewhat close to the Planckian locus.
+
+    Args:
+        tags (Dict[str, Any]): Tags dictionary as held by exifread.
+
+    Raises:
+        KeyError: Raised if AsShotNeutral was not in the tag dictionary.
+
+    Returns:
+        np.ndarray: AsShotNeutral channel multipliers.
+    """
+
+    as_shot_neutral = np.zeros(3, dtype=np.float32)
+    idx = 0
+    for x in range(as_shot_neutral.shape[0]):
+        try:
+            as_shot_neutral[x] = tags["Image Tag 0xC628"].values[idx].decimal()
+        except:
+            raise KeyError("AsShotNeutral missing inside tags!")
+        idx += 1
+    return as_shot_neutral

--- a/wb_cct/standard_ill.py
+++ b/wb_cct/standard_ill.py
@@ -1,0 +1,85 @@
+from enum import IntEnum, auto
+from typing import Dict, Tuple
+
+# Source for all this info is https://en.wikipedia.org/wiki/Standard_illuminant
+#     as of 22/1/25.
+# Yes, citing a wiki is bad, the numbers seem fine!
+
+class StandardIlluminant(IntEnum):
+    A = auto()
+    B = auto()
+    C = auto()
+    D50 = auto()
+    D55 = auto()
+    D65 = auto()
+    D75 = auto()
+    F1 = auto()
+    F2 = auto()
+    F3 = auto()
+    F4 = auto()
+    F5 = auto()
+
+STANDARD_ILLUMINANT_TO_XY : Dict[StandardIlluminant, Tuple[float,float]] = {
+    
+    StandardIlluminant.A : (0.44758, 0.40745),
+    StandardIlluminant.B : (0.34842, 0.35161),
+    StandardIlluminant.C : (0.31006, 0.31616),
+    StandardIlluminant.D50 : (0.34567, 0.35850),
+    StandardIlluminant.D55 : (0.33242, 0.34743),
+    StandardIlluminant.D65 : (0.31272, 0.32903),
+    StandardIlluminant.D75 : (0.29902, 0.31485),
+    StandardIlluminant.F1 : (0.31310, 0.33727),
+    StandardIlluminant.F2 : (0.37208, 0.37529),
+    StandardIlluminant.F3 : (0.40910, 0.39430),
+    StandardIlluminant.F4 : (0.44018, 0.40329),
+    StandardIlluminant.F5 : (0.31379, 0.34531)
+}
+
+LIGHTSOURCE_TO_STANDARD_ILLUMINANT : Dict[int, StandardIlluminant] = {
+    12:StandardIlluminant.F1,
+    13:StandardIlluminant.F5,
+    14:StandardIlluminant.F2,
+    15:StandardIlluminant.F3,
+    16:StandardIlluminant.F4,
+    17:StandardIlluminant.A,
+    18:StandardIlluminant.B,
+    19:StandardIlluminant.C,
+    20:StandardIlluminant.D55,
+    21:StandardIlluminant.D65,
+    22:StandardIlluminant.D75,
+    23:StandardIlluminant.D50
+}
+
+def get_chromacity_from_illuminant(ill : StandardIlluminant) -> Tuple[float,float]:
+    """Get CIE 1931 chromacities for a standard illuminant.
+
+    Args:
+        ill (StandardIlluminant): Standard illuminant.
+
+    Raises:
+        KeyError: Raised if illuminant has no defined chromacity.
+
+    Returns:
+        Tuple[float,float]: (x,y) white point.
+    """
+    if ill in STANDARD_ILLUMINANT_TO_XY:
+        return STANDARD_ILLUMINANT_TO_XY[ill]
+    raise KeyError("Illuminant", StandardIlluminant.A.name, "has no defined chromacity value!")
+
+def get_illuminant_from_lightsource(id : int) -> StandardIlluminant:
+    """Get the equivalent StandardIlluminant enum member for an EXIF LightSource tag.
+
+    Args:
+        id (int): EXIF LightSource tag value.
+
+    Raises:
+        KeyError: Raised if LightSource has no mapping. Many IDs do not have a corresponding
+        standard illuminant as they are vague so other EXIF tags may be needed to find either
+        predicted CCT or chromacity.
+
+    Returns:
+        StandardIlluminant: Equivalent standard illuminant.
+    """
+    if id in LIGHTSOURCE_TO_STANDARD_ILLUMINANT:
+        return LIGHTSOURCE_TO_STANDARD_ILLUMINANT[id]
+    raise KeyError("ID", id, "either unimplemented or has no corresponding standard illuminant.")


### PR DESCRIPTION
Current main branch has some wrong implementations of white balancing. sRGB uses D65 reference white, we use reference white from AsShotNeutral. This needs to be adapted out but pySP isn't aware of the neutral point of the image.

These changes rip old the old white balancing system and replace it with a proper Planckian-locus based system. It somewhat follows DNG spec (Mired blending is usually ignored since it doesn't match other software). It does the following:
- Extends EXIF parsing to get camera calibration and neutral tags
- Reworks images to allow changing of neutral
- Interpolates camera calibration to get XYZ coords when provided neutral
- Computes new neutral if user wishes to set neutral by temperature
- Automatically adjusts tint to align with D-series illuminants
- Computes own matrix for converting from camera to XYZ
- Adapts matrix using Bradford adaptation from computed scene illuminant to fixed D65
- misc README and requirement fixups

This hasn't be comprehensively tested (no surprises) but is pretty important to fixup the quality of the output. The output is much more neutral and blues become much more saturated. The maths behind the color conversion broadly matches other software, and neutral to temperature is typically within 100K at extremes and <5K within D-series.