### PR TITLE
Add simple sharpening both at display level and capture level

### DIFF
--- a/colorize/transform.py
+++ b/colorize/transform.py
@@ -109,3 +109,54 @@ def srgb_to_lin_srgb(srgb : np.ndarray) -> np.ndarray:
     """
     srgb_working = clip_rgb(srgb)
     return np.where(srgb_working <= 0.04045, srgb_working / 12.92, ((srgb_working + 0.055) / 1.055) ** 2.4)
+
+# Oklab operators taken from fezzypixels (i wrote it, its okay)
+def lin_srgb_to_oklab(lin_srgb : np.ndarray) -> np.ndarray:
+	"""Convert a linearized sRGB image to Oklab.
+
+	Args:
+		lin_srgb (np.ndarray): Linearized sRGB image.
+
+	Returns:
+		np.ndarray: Oklab image.
+	"""
+	# Credit - https://bottosson.github.io/posts/oklab/
+	r,g,b = lin_srgb[...,0], lin_srgb[...,1], lin_srgb[...,2]
+
+	l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b
+	m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b
+	s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b
+
+	l_prime = np.cbrt(l)
+	m_prime = np.cbrt(m)
+	s_prime = np.cbrt(s)
+
+	ok_l = 0.2104542553 * l_prime + 0.7936177850 * m_prime - 0.0040720468 * s_prime
+	ok_a = 1.9779984951 * l_prime - 2.4285922050 * m_prime + 0.4505937099 * s_prime
+	ok_b = 0.0259040371 * l_prime + 0.7827717662 * m_prime - 0.8086757660 * s_prime
+	return np.dstack((ok_l,ok_a,ok_b))
+
+def oklab_to_lin_srgb(oklab : np.ndarray) -> np.ndarray:
+	"""Convert an Oklab image to linear sRGB.
+
+	Args:
+		oklab (np.ndarray): Oklab image. No clamping is applied.
+
+	Returns:
+		np.ndarray: Linearized sRGB image.
+	"""
+	# Credit - https://bottosson.github.io/posts/oklab/
+	ok_l,ok_a,ok_b = oklab[...,0], oklab[...,1], oklab[...,2]
+    
+	l_prime = ok_l + 0.3963377774 * ok_a + 0.2158037573 * ok_b
+	m_prime = ok_l - 0.1055613458 * ok_a - 0.0638541728 * ok_b
+	s_prime = ok_l - 0.0894841775 * ok_a - 1.2914855480 * ok_b
+
+	l_prime = l_prime ** 3
+	m_prime = m_prime ** 3
+	s_prime = s_prime ** 3
+
+	r =  4.0767416621 * l_prime - 3.3077115913 * m_prime + 0.2309699292 * s_prime
+	g = -1.2684380046 * l_prime + 2.6097574011 * m_prime - 0.3413193965 * s_prime
+	b = -0.0041960863 * l_prime - 0.7034186147 * m_prime + 1.7076147010 * s_prime
+	return np.dstack((r,g,b))

--- a/debayer/ahd.py
+++ b/debayer/ahd.py
@@ -47,6 +47,8 @@ def debayer(image : Union[RawRgbgData_BaseType], postprocess_stages : int = 1) -
                                             g * wb_coeff[1],
                                             b * wb_coeff[2])), image.cam_wb.get_matrix(), clip_highlights=False)
         
+        # NOTE - Oklab methods work here, quality is similar
+        # I don't know what CV2 is doing. Unfortunately CV2 is like 20% faster to do color transforms so leave it here
         if image.get_hdr():
             # If the image is HDR, we can't formulate a CIELAB representation
             # Instead, use luma for L* and tonemap to get A*B*.
@@ -85,7 +87,7 @@ def debayer(image : Union[RawRgbgData_BaseType], postprocess_stages : int = 1) -
     #        Do not set this value too high or you'll experience debugging hell
     h_optimal   = np.array([-0.2569, 0.4339, 0.5138, 0.4339, -0.2569], dtype=np.float32)
     h_fast      = np.array([-0.25, 0.5, 0.5, 0.5, -0.25], dtype=np.float32)
-    ratio_optimal = 0.0
+    ratio_optimal = 0.125
     h = (h_optimal * ratio_optimal) + (h_fast * (1 - ratio_optimal))
 
     # Interpolate green channel from red

--- a/filter/blur/__init__.py
+++ b/filter/blur/__init__.py
@@ -1,0 +1,1 @@
+from .blur_gaussian import blur_gaussian

--- a/filter/blur/blur_gaussian.py
+++ b/filter/blur/blur_gaussian.py
@@ -1,0 +1,102 @@
+import numpy as np
+import cv2
+
+def get_gaussian_filter_window_size(sigma : float, cutoff : int = 3) -> int:
+    """Get the width of the window required for a given Gaussian blur kernel.
+
+    This method doesn't compute the kernel, just returns the size of the window needed to store the kernel while avoiding obvious cutoff at filter edges.
+
+    Args:
+        sigma (float): Reach of the bell part of the curve. Comparable to radius where higher sigma (standard deviation) means more blur reach.
+        cutoff (int, optional): How many standard deviations to preserve. More deviations means more terms which worsens performance. 3 deviations captures basically the whole bell. Defaults to 3.
+
+    Raises:
+        ValueError: Raised if sigma is invalid, i.e., negative.
+
+    Returns:
+        int: Maximum window size for 1D gaussian that contains the amount of deviations needed for sigma.
+    """
+    if sigma < 0:
+        raise ValueError("Filter cannot be computed with negative sigma!")
+    
+    # Typically past 3 sd the filter approaches 0
+    # https://en.wikipedia.org/wiki/Gaussian_blur#Mechanics
+    radius = sigma * cutoff
+    diameter = np.ceil(radius * 2)
+
+    if diameter % 2 == 0:
+        diameter += 1
+
+    return max(3, diameter)
+
+def get_1d_gaussian_filter(sigma : float) -> np.ndarray:
+    """Return a 1D Gaussian filter for a given sigma.
+
+    The size of the kernel is computed according to sigma. It is always odd and is close to sigma * 6 so that the Gaussian bell is approximated completely.
+
+    Args:
+        sigma (float): Reach of the bell part of the curve. Comparable to radius where higher sigma (standard deviation) means more blur reach.
+
+    Returns:
+        np.ndarray: 1D Gaussian bell. Size is automatically computed.
+    """
+
+    try:
+        radius = get_gaussian_filter_window_size(sigma) // 2
+    except ValueError:
+        return np.array([[1]])
+    
+    filter = np.arange(-radius, radius + 1, 1)
+
+    denom = 1 / (np.sqrt(2 * np.pi) * sigma)
+    filter = np.exp(-filter ** 2 / (2 * sigma ** 2))
+
+    filter = denom * filter
+    return filter
+
+def blur_gaussian(image : np.ndarray, sigma : float) -> np.ndarray:
+    """Perform a Gaussian blur.
+
+    This uses a 2-pass approach to reduce computation. Edges are reflected which may produce artifacts.
+
+    Args:
+        image (np.ndarray): Base image. Must be of shape (a,b,<channels>) or (a,b).
+        sigma (float): Reach of the bell part of the curve. Comparable to radius where higher sigma (standard deviation) means more blur reach.
+
+    Returns:
+        np.ndarray: Blurred image. Same shape as original.
+    """
+
+    # TODO - Cython this, a bit slow for larger images.
+
+    # This is a simple Gaussian blur in 2-pass mode (takes advantage of separability)
+    # This reduces overall computation:
+    #     A separated filter has length N so needs N products to solve
+    #     The full 2D filter is size NxN so needs N*N products to solve
+    #     The full filter can be solved by doing 2 separated filters so 2N instead of N*2
+    #         operations.
+
+    filter = get_1d_gaussian_filter(sigma)
+    border = filter.shape[0] // 2
+
+    image_replicated = cv2.copyMakeBorder(image, border, border, border, border, cv2.BORDER_REFLECT)
+
+    # Duplicate the shape, don't hardcode channels so we can support anything of shape (a,b,<channels>) or just (a,b)
+    padded_shape = list(image.shape)
+    padded_shape[0] += border + border
+
+    h_pass = np.zeros(shape=padded_shape, dtype=np.float32)
+
+    # Blur in X
+    for idx_coeff, coeff in enumerate(filter):
+        h_pass[:,:] += (image_replicated[:,idx_coeff:idx_coeff + image.shape[1]] * coeff)
+    
+    # Free padded image, start V blur
+    del image_replicated
+    v_pass = np.zeros_like(image, dtype=np.float32)
+
+    # Blur in Y
+    for idx_coeff, coeff in enumerate(filter):
+            v_pass[:,:] += (h_pass[idx_coeff:idx_coeff + image.shape[0]] * coeff)
+
+    return v_pass

--- a/filter/sharpen/__init__.py
+++ b/filter/sharpen/__init__.py
@@ -1,1 +1,2 @@
 from .unsharp import unsharp_mask_lab, unsharp_mask_per_channel
+from .gauss_rt_deconv import gaussian_rt_deconvolution

--- a/filter/sharpen/__init__.py
+++ b/filter/sharpen/__init__.py
@@ -1,0 +1,1 @@
+from .unsharp import unsharp_mask_lab, unsharp_mask_per_channel

--- a/filter/sharpen/gauss_rt_deconv.py
+++ b/filter/sharpen/gauss_rt_deconv.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pySP.colorize import lin_srgb_to_oklab, oklab_to_lin_srgb
+from pySP.colorize.transform import lin_srgb_to_oklab, oklab_to_lin_srgb
 from pySP.filter.blur import blur_gaussian
 
 def gaussian_rt_deconvolution(image : np.ndarray, sigma : float, iterations : int = 20) -> np.ndarray:

--- a/filter/sharpen/gauss_rt_deconv.py
+++ b/filter/sharpen/gauss_rt_deconv.py
@@ -1,0 +1,100 @@
+import numpy as np
+
+from pySP.colorize import lin_srgb_to_oklab, oklab_to_lin_srgb
+from pySP.filter.blur import blur_gaussian
+
+def gaussian_rt_deconvolution(image : np.ndarray, sigma : float, iterations : int = 20) -> np.ndarray:
+    """Richardson-Lucy deconvolution operating on a per-channel basis. This is a reconstruction method
+    so is effective at boosting general sharpness and detail.
+
+    This is a semi-blind operation and assumes the convolution was Gaussian-like. Adjust sigma until
+    real details become clearer. If the image continually degrades it is likely Gaussian kernels do
+    not fit well. Use a different sharpening method instead.
+
+    Args:
+        image (np.ndarray): Image, any range, must be of shape (a,b,<channels>) or (a,b).
+        sigma (float): Radius for blur kernel.
+        iterations (int, optional): Iterations. Lower values are faster and less artifact prone but reduce strength. Defaults to 20.
+
+    Returns:
+        np.ndarray: Unclipped sharpened image. Values may exceed ranges of original.
+    """
+
+    # Credits
+    # Theory - https://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
+    # Breakdown - https://stargazerslounge.com/topic/228147-lucy-richardson-deconvolution-so-what-is-it/
+
+    # General case is simplified by Gaussian kernel being symmetrical - we can avoid inverse PSF
+
+    estimate = np.copy(image)
+
+    for i in range(iterations):
+        blurred_estimate = blur_gaussian(estimate, sigma)
+        estimate_factor = blur_gaussian(image / (blurred_estimate + 1e-25), sigma)  # Very small float to avoid divide by zero
+
+        estimate = estimate * estimate_factor
+    
+    return estimate
+
+def gaussian_rt_deconvolution_lab(lin_srgb : np.ndarray, radius : float, iterations : int = 20) -> np.ndarray:
+    """Richardson-Lucy deconvolution operating in a LAB space. This is a reconstruction method
+    so is effective at boosting general sharpness and detail.
+
+    This is a semi-blind operation and assumes the convolution was Gaussian-like. Adjust sigma until
+    real details become clearer. If the image continually degrades it is likely Gaussian kernels do
+    not fit well. Use a different sharpening method instead.
+
+    This applies deconvolution to just the L channel, avoiding color artifacts. Keep the amount sensible to
+    prevent crunchiness between the color and lightness information.
+
+    Args:
+        lin_srgb (np.ndarray): Linearized sRGB image, must be of shape (a,b,3) with order RGB. Should be in [0,1] per channel for transforms to be valid.
+        sigma (float): Radius for blur kernel.
+        iterations (int, optional): Iterations. Lower values are faster and less artifact prone but reduce strength. Defaults to 20.
+
+    Returns:
+        np.ndarray: Unclipped sharpened image. Values may exceed ranges of original.
+    """
+
+    lab = lin_srgb_to_oklab(lin_srgb)
+
+    lab[:,:,0] = gaussian_rt_deconvolution(lab[:,:,0], radius, iterations)
+    
+    return oklab_to_lin_srgb(lab)
+
+def gaussian_rt_deconvolution_yuv(lin_srgb : np.ndarray, radius : float, iterations : int = 20) -> np.ndarray:
+    """Richardson-Lucy deconvolution operating in YUV space. This is a reconstruction method
+    so is effective at boosting general sharpness and detail.
+
+    This is a semi-blind operation and assumes the convolution was Gaussian-like. Adjust sigma until
+    real details become clearer. If the image continually degrades it is likely Gaussian kernels do
+    not fit well. Use a different sharpening method instead.
+
+    This applies only to the Y channel in a YUV color space in linear space. Because YUV isn't
+    perceptual, it preserves linearity which makes it better for sensor-level or HDR transforms.
+    Although this is more 'correct' for those applications, LAB might still result in a more natural
+    result. Keep the amount sensible to prevent crunchiness between the color and lightness
+    information.
+
+    Args:
+        lin_srgb (np.ndarray): Linearized sRGB image, must be of shape (a,b,3) with order RGB. Should be in [0,1] per channel for transforms to be valid.
+        sigma (float): Radius for blur kernel.
+        iterations (int, optional): Iterations. Lower values are faster and less artifact prone but reduce strength. Defaults to 20.
+
+    Returns:
+        np.ndarray: Unclipped sharpened image. Values may exceed ranges of original.
+    """
+
+    y = 0.299 * lin_srgb[:,:,0] + 0.587 * lin_srgb[:,:,1] + 0.114 * lin_srgb[:,:,2]
+    
+    y_modified = gaussian_rt_deconvolution(y, radius, iterations)
+
+    # In theory, perceptual UV could modify the scale factor per channel. This is acceptable for now
+    scale_factor = y_modified / y
+
+    rgb_shifted = np.zeros_like(lin_srgb)
+    rgb_shifted[:,:,0] = lin_srgb[:,:,0] * scale_factor
+    rgb_shifted[:,:,1] = lin_srgb[:,:,1] * scale_factor
+    rgb_shifted[:,:,2] = lin_srgb[:,:,2] * scale_factor
+    return rgb_shifted
+

--- a/filter/sharpen/unsharp.py
+++ b/filter/sharpen/unsharp.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pySP.colorize import lin_srgb_to_oklab, oklab_to_lin_srgb
+from pySP.colorize.transform import lin_srgb_to_oklab, oklab_to_lin_srgb
 from pySP.filter.blur import blur_gaussian
 
 def unsharp_mask_per_channel(image : np.ndarray, radius : float, amount : float) -> np.ndarray:

--- a/filter/sharpen/unsharp.py
+++ b/filter/sharpen/unsharp.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from pySP.colorize import lin_srgb_to_oklab, oklab_to_lin_srgb
+from pySP.filter.blur import blur_gaussian
+
+def unsharp_mask_per_channel(image : np.ndarray, radius : float, amount : float) -> np.ndarray:
+    """Unsharp mask operating on a per-channel basis.
+
+    This uses naive unsharp on every channel. On RGB images, for example, expect overshoot and fringing.
+
+    Args:
+        image (np.ndarray): Image, any range, must be of shape (a,b,<channels>) or (a,b).
+        radius (float): Radius for high pass blur kernel.
+        amount (float): Amount of sharpening. Sensible values are in [0,1] but there is no restriction.
+
+    Returns:
+        np.ndarray: Unclipped sharpened image. Values may exceed ranges of original.
+    """
+
+    high_pass = image - blur_gaussian(image, radius)
+    return image + high_pass * amount
+
+def unsharp_mask_lab(lin_srgb : np.ndarray, radius : float, amount : float) -> np.ndarray:
+    """Unsharp mask operating in a LAB space.
+
+    This applies unsharp to just the L channel, avoiding color artifacts. Keep the amount sensible to
+    prevent crunchiness between the color and lightness information.
+
+    Args:
+        lin_srgb (np.ndarray): Linearized sRGB image, must be of shape (a,b,3) with order RGB. Should be in [0,1] per channel for transforms to be valid.
+        radius (float): Radius for high pass blur kernel.
+        amount (float): Amount of sharpening. Sensible values are in [0,1] but there is no restriction.
+
+    Returns:
+        np.ndarray: Unclipped sharpened image in linearized sRGB space. Values may exceed ranges of original.
+    """
+
+    lab = lin_srgb_to_oklab(lin_srgb)
+
+    lab[:,:,0] = unsharp_mask_per_channel(lab[:,:,0], radius, amount)
+    
+    return oklab_to_lin_srgb(lab)

--- a/filter/sharpen/unsharp.py
+++ b/filter/sharpen/unsharp.py
@@ -4,7 +4,8 @@ from pySP.colorize import lin_srgb_to_oklab, oklab_to_lin_srgb
 from pySP.filter.blur import blur_gaussian
 
 def unsharp_mask_per_channel(image : np.ndarray, radius : float, amount : float) -> np.ndarray:
-    """Unsharp mask operating on a per-channel basis.
+    """Unsharp mask operating on a per-channel basis. This is a microcontrast boosting method so is
+    effective improving edge sharpness and overall clarity.
 
     This uses naive unsharp on every channel. On RGB images, for example, expect overshoot and fringing.
 
@@ -21,7 +22,8 @@ def unsharp_mask_per_channel(image : np.ndarray, radius : float, amount : float)
     return image + high_pass * amount
 
 def unsharp_mask_lab(lin_srgb : np.ndarray, radius : float, amount : float) -> np.ndarray:
-    """Unsharp mask operating in a LAB space.
+    """Unsharp mask operating in a LAB space. This is a microcontrast boosting method so is
+    effective improving edge sharpness and overall clarity.
 
     This applies unsharp to just the L channel, avoiding color artifacts. Keep the amount sensible to
     prevent crunchiness between the color and lightness information.


### PR DESCRIPTION
pySP's results are blurrier than other software because of sharpening in their pipelines. This pull adds two sharpening operators running in a variety of colorspaces:

- Unsharp mask for improving microcontrast. This is cheap and pleasing but doesn't sharpen detail and can end up with stylization and ringing when pushed.
- Richardson-Lucy deconvolution. This was inspired by RawTherapee although is very basic by comparison since it was based off of the discussion on pixls and the wiki page. By assuming the image was taken with a Gaussian blur, we can step backwards to sharpen the image. This works well for countering light lens blur and is useful since our AHD demosaic also uses Gaussian kernels. Kernel must be determined beforehand and early stopping isn't supported (yet). This produces a much more convincing sharpening effect with less ringing than unsharp.

A custom Gaussian blur operator is added for precise small-scale blurring with automatic kernel sizes and separable execution for better runtime.

Both techniques support a variety of colorspaces although ideally only work on brightness and not color data (unless you want fringing). OkLAB is added for sharpening L* only for general case and YUV is supported for working with color-corrected raw data ("capture sharpening") or HDR data.

AHD was tested using OkLAB and the result wasn't radically different - even though not much is known about OpenCV's LAB transform, it seems to work okay for demosaicing. I've left AHD the same (other than tweaking maze param) since runtime with CV2 is better.