### PR TITLE
Support all 2x2 Bayer sensor configurations

### DIFF
--- a/base_types/image_base.py
+++ b/base_types/image_base.py
@@ -1,12 +1,22 @@
-from typing import Optional
+from __future__ import annotations
+
+from enum import IntEnum, auto
+from typing import Optional, Tuple
 import numpy as np
 
 from pySP.colorize.transform import cam_to_lin_srgb
 from pySP.const import QualityDemosaic
 from pySP.wb_cct.cam_wb import CameraWhiteBalanceController
 from pySP.wb_cct.helpers_cam_mat import MatXyzToCamera
+from abc import abstractmethod
 
-class RawDebayerData():
+class BayerPattern(IntEnum):
+    Rggb = auto()
+    Bggr = auto()
+    Grbg = auto()
+    Gbrg = auto()
+
+class RawDemosaicData():
     def __init__(self, image : np.ndarray, wb_coeff : np.ndarray, wb_norm : bool = False):
         """Class for storing RGB pixel data after debayering.
 
@@ -53,17 +63,14 @@ class RawDebayerData():
         self.wb_apply()
         return cam_to_lin_srgb(self.image, self.mat_xyz)
 
-class RawRgbgData_BaseType():
+class RawCameraData_BaseType():
     def __init__(self):
-        """Base class for storing raw RGBG Bayer sensor data. This is primarily for subclasses and typing. Do not instantiate this class manually.
-        """
-
-        self.bayer_data_scaled  : np.ndarray = None
+        self.sensor_scaled      : np.ndarray = None
         self.cam_wb             : CameraWhiteBalanceController = None
         self.current_ev         : float      = np.inf
         self.lim_sat            : float      = 1.0
         self.__is_hdr           : bool       = False
-
+    
     def set_hdr(self, is_hdr : bool):
         """Set whether the image should be treated as HDR or not.
 
@@ -78,18 +85,11 @@ class RawRgbgData_BaseType():
         Returns:
             bool: True if HDR.
         """
-        # TODO - Return True if any part of bayer_data_scaled is greater than 1. 
         return self.__is_hdr
     
-    def is_valid(self) -> bool:
-        """Check if contents of this image are valid, i.e., are expected.
-
-        Returns:
-            bool: True if image is valid; False otherwise.
-        """
-        return type(self.bayer_data_scaled) != type(None) and type(self.cam_wb) != type(None) and self.current_ev != np.inf
-
-    def debayer(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> Optional[RawDebayerData]:
+    @classmethod
+    @abstractmethod
+    def demosaic(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> RawDemosaicData:
         """Debayer this image. Override this method. This is intentionally unimplemented for the base class.
 
         Args:
@@ -97,7 +97,28 @@ class RawRgbgData_BaseType():
             postprocess_steps (int, optional): Amount of divergence correction steps. Lower values retain detail but leave artifacts. Ignored unless using Best quality. Defaults to 1.
 
         Returns:
-            Optional[RawDebayerData]: Base class always returns None.
+            RawDebayerData: Debayered image.
         """
-
         return None
+
+class RawBayerData_BaseType(RawCameraData_BaseType):
+    def __init__(self):
+        """Base class for storing raw RGBG Bayer sensor data. This is primarily for subclasses and typing. Do not instantiate this class manually.
+        """
+        super().__init__()
+        self.sensor_pattern : BayerPattern = None
+    
+    @classmethod
+    @abstractmethod
+    def to_rggb(self) -> RawRggbBayerData_BaseType:
+        return None
+
+class RawRggbBayerData_BaseType(RawCameraData_BaseType):
+    def __init__(self, sensor_scaled : np.ndarray, cam_wb : CameraWhiteBalanceController, shot_ev : float, lim_sat : float,
+                 source_pattern = BayerPattern.Rggb):
+        super().__init__()
+        self.sensor_scaled = sensor_scaled
+        self.cam_wb = cam_wb
+        self.current_ev = shot_ev
+        self.lim_sat = lim_sat
+        self.source_pattern : BayerPattern = source_pattern

--- a/corr_ca/ca_removal.py
+++ b/corr_ca/ca_removal.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import cv2
 import numpy as np
 
-from pySP.base_types.image_base import RawRgbgData_BaseType
+from pySP.base_types.image_base import RawBayerData_BaseType
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from pySP.corr_ca.instability import compute_structural_instability
 from pySP.corr_ca.model.generic import CaCorrectionModel, ReversibleModelMixin
@@ -12,7 +12,7 @@ from pySP.debayer.edge_assisted_gaussian import resample_g_to_full_resolution
 from pySP.debayer.edge_assisted_gaussian import resample_b, resample_r
 from pySP.corr_ca.solver.radial_offset_solver import get_scale_pairs_using_pooled_tiler
 
-def compute_ca_lens_models_for_raw(raw : RawRgbgData_BaseType, init_model_r : Optional[CaCorrectionModel] = Poly5CorrectionModel(), init_model_b : Optional[CaCorrectionModel] = Poly5CorrectionModel(),
+def compute_ca_lens_models_for_raw(raw : RawBayerData_BaseType, init_model_r : Optional[CaCorrectionModel] = Poly5CorrectionModel(), init_model_b : Optional[CaCorrectionModel] = Poly5CorrectionModel(),
                                    max_distortion_additional_scale : float = 0.004) -> Tuple[Optional[CaCorrectionModel], Optional[CaCorrectionModel]]:
     """Fit lens distortion models for removing chromatic abberation by aligning the red and blue channels onto green. This method makes the following assumptions:
     - The chromatic abberation is lateral, i.e., fringing that worsens towards the edges of the image
@@ -45,7 +45,7 @@ def compute_ca_lens_models_for_raw(raw : RawRgbgData_BaseType, init_model_r : Op
     
     return (init_model_r, init_model_b)
 
-def remove_ca_from_raw(raw : RawRgbgData_BaseType, lens_model_r : Optional[CaCorrectionModel], lens_model_b : Optional[CaCorrectionModel]):
+def remove_ca_from_raw(raw : RawBayerData_BaseType, lens_model_r : Optional[CaCorrectionModel], lens_model_b : Optional[CaCorrectionModel]):
     """Remove lateral chromatic abberation from a raw file by applying inverse lens distortions onto the red and blue channels to align it with green.
 
     This method overwrites the source Bayer data with corrected channels. Resampling is performed - repeated uses of this method may lead to
@@ -86,7 +86,7 @@ def remove_ca_from_raw(raw : RawRgbgData_BaseType, lens_model_r : Optional[CaCor
         raise ValueError("Blue lens model is not reversible so green cannot be re-aligned to remove error. Use a reversible model and try again.")
     
     # Resample green using simple upsample approach. We want as high res as possible so we can resample G further without major quality loss
-    r, g1, b, g2 = bayer_to_rgbg(raw.bayer_data_scaled)
+    r, g1, b, g2 = bayer_to_rgbg(raw.sensor_scaled)
     g_resampled = resample_g_to_full_resolution(g1, g2)
 
     # For both channels, this is the workflow:
@@ -129,4 +129,4 @@ def remove_ca_from_raw(raw : RawRgbgData_BaseType, lens_model_r : Optional[CaCor
         
         b = bayer_to_rgbg(b_at_g)[2] / raw.cam_wb.get_reciprocal_multipliers()[2]
     
-    raw.bayer_data_scaled = rgbg_to_bayer(r, g1, b, g2)
+    raw.sensor_scaled = rgbg_to_bayer(r, g1, b, g2)

--- a/corr_ca/ca_removal.py
+++ b/corr_ca/ca_removal.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import cv2
 import numpy as np
 
-from pySP.base_types.image_base import RawBayerData_BaseType
+from pySP.base_types.image_base import RawRggbBayerData_BaseType
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from pySP.corr_ca.instability import compute_structural_instability
 from pySP.corr_ca.model.generic import CaCorrectionModel, ReversibleModelMixin
@@ -12,7 +12,7 @@ from pySP.debayer.edge_assisted_gaussian import resample_g_to_full_resolution
 from pySP.debayer.edge_assisted_gaussian import resample_b, resample_r
 from pySP.corr_ca.solver.radial_offset_solver import get_scale_pairs_using_pooled_tiler
 
-def compute_ca_lens_models_for_raw(raw : RawBayerData_BaseType, init_model_r : Optional[CaCorrectionModel] = Poly5CorrectionModel(), init_model_b : Optional[CaCorrectionModel] = Poly5CorrectionModel(),
+def compute_ca_lens_models_for_raw(raw : RawRggbBayerData_BaseType, init_model_r : Optional[CaCorrectionModel] = Poly5CorrectionModel(), init_model_b : Optional[CaCorrectionModel] = Poly5CorrectionModel(),
                                    max_distortion_additional_scale : float = 0.004) -> Tuple[Optional[CaCorrectionModel], Optional[CaCorrectionModel]]:
     """Fit lens distortion models for removing chromatic abberation by aligning the red and blue channels onto green. This method makes the following assumptions:
     - The chromatic abberation is lateral, i.e., fringing that worsens towards the edges of the image
@@ -45,7 +45,7 @@ def compute_ca_lens_models_for_raw(raw : RawBayerData_BaseType, init_model_r : O
     
     return (init_model_r, init_model_b)
 
-def remove_ca_from_raw(raw : RawBayerData_BaseType, lens_model_r : Optional[CaCorrectionModel], lens_model_b : Optional[CaCorrectionModel]):
+def remove_ca_from_raw(raw : RawRggbBayerData_BaseType, lens_model_r : Optional[CaCorrectionModel], lens_model_b : Optional[CaCorrectionModel]):
     """Remove lateral chromatic abberation from a raw file by applying inverse lens distortions onto the red and blue channels to align it with green.
 
     This method overwrites the source Bayer data with corrected channels. Resampling is performed - repeated uses of this method may lead to

--- a/corr_ca/instability.py
+++ b/corr_ca/instability.py
@@ -2,9 +2,9 @@ from typing import List, Tuple
 import cv2
 import numpy as np
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
-from pySP.image import RawBayerData
+from pySP.image import RawRggbBayerData
 
-def compute_structural_instability(image : RawBayerData) -> np.ndarray:
+def compute_structural_instability(image : RawRggbBayerData) -> np.ndarray:
     # Compute simple WB using stored WB. Recommended to set to good value prior to everything
     wb_coeff = image.cam_wb.get_reciprocal_multipliers()
 

--- a/corr_ca/instability.py
+++ b/corr_ca/instability.py
@@ -2,14 +2,14 @@ from typing import List, Tuple
 import cv2
 import numpy as np
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
-from pySP.image import RawRgbgData
+from pySP.image import RawBayerData
 
-def compute_structural_instability(image : RawRgbgData) -> np.ndarray:
+def compute_structural_instability(image : RawBayerData) -> np.ndarray:
     # Compute simple WB using stored WB. Recommended to set to good value prior to everything
     wb_coeff = image.cam_wb.get_reciprocal_multipliers()
 
     # Paper - apply wb coeff NOW
-    r,g0,b,g1 = bayer_to_rgbg(np.copy(image.bayer_data_scaled))
+    r,g0,b,g1 = bayer_to_rgbg(np.copy(image.sensor_scaled))
     r *= wb_coeff[0]
     g0 *= wb_coeff[1]
     g1 *= wb_coeff[1]

--- a/debayer/ahd.py
+++ b/debayer/ahd.py
@@ -5,13 +5,13 @@ import numpy as np
 
 from pySP.debayer.edge_assisted_gaussian import resample_channel
 
-from ..base_types.image_base import RawDebayerData, RawRgbgData_BaseType
+from ..base_types.image_base import RawDemosaicData, RawBayerData_BaseType
 from ..bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from ..colorize.transform import cam_to_lin_srgb
 from .ahd_homogeneity_cython import build_map
 from .gaussian import CV2_DEFAULT_KERNEL_SIGMA, BayerPatternPosition
 
-def debayer(image : Union[RawRgbgData_BaseType], postprocess_stages : int = 1) -> Optional[RawDebayerData]:
+def debayer(image : Union[RawBayerData_BaseType], postprocess_stages : int = 1) -> Optional[RawDemosaicData]:
     """Debayer using the Adaptive Homogeneity-Directed Demosaicing algorithm by Hirakawa and Parks (2005).
 
     This is slow but produces high-quality results with reduced zippering and smooth graduation.
@@ -66,10 +66,7 @@ def debayer(image : Union[RawRgbgData_BaseType], postprocess_stages : int = 1) -
         homogeneity = build_map(lab, k_pad, domain_k, is_vertical)
         return homogeneity
 
-    if not(image.is_valid()):
-        return None
-
-    r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
+    r, g1, b, g2 = bayer_to_rgbg(image.sensor_scaled)
 
     # White balance early, we can avoid some mess with postprocessing and why not
     # Tweaks some microcontrast. No biggie
@@ -167,7 +164,7 @@ def debayer(image : Union[RawRgbgData_BaseType], postprocess_stages : int = 1) -
     for _i in range(postprocess_stages):
         debayered = postprocess_color(debayered)
 
-    debayered = RawDebayerData(debayered, wb_coeff, wb_norm=False)
+    debayered = RawDemosaicData(debayered, wb_coeff, wb_norm=False)
     debayered.mat_xyz = image.cam_wb.get_matrix()
     debayered.current_ev = image.current_ev
     return debayered

--- a/debayer/ahd.py
+++ b/debayer/ahd.py
@@ -5,13 +5,13 @@ import numpy as np
 
 from pySP.debayer.edge_assisted_gaussian import resample_channel
 
-from ..base_types.image_base import RawDemosaicData, RawBayerData_BaseType
+from ..base_types.image_base import RawDemosaicData, RawRggbBayerData_BaseType
 from ..bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from ..colorize.transform import cam_to_lin_srgb
 from .ahd_homogeneity_cython import build_map
 from .gaussian import CV2_DEFAULT_KERNEL_SIGMA, BayerPatternPosition
 
-def debayer(image : Union[RawBayerData_BaseType], postprocess_stages : int = 1) -> Optional[RawDemosaicData]:
+def debayer(image : RawRggbBayerData_BaseType, postprocess_stages : int = 1) -> RawDemosaicData:
     """Debayer using the Adaptive Homogeneity-Directed Demosaicing algorithm by Hirakawa and Parks (2005).
 
     This is slow but produces high-quality results with reduced zippering and smooth graduation.

--- a/debayer/edge_assisted_gaussian.py
+++ b/debayer/edge_assisted_gaussian.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, Union
 import cv2
 import numpy as np
 
-from pySP.base_types.image_base import RawDebayerData, RawRgbgData_BaseType
+from pySP.base_types.image_base import RawDemosaicData, RawBayerData_BaseType
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from pySP.debayer.gaussian import CV2_DEFAULT_KERNEL_SIGMA, CV2_DEFAULT_UNNORM_GAUSSIAN_KERNEL, BayerPatternPosition, get_rgbg_kernel
 
@@ -185,11 +185,9 @@ def resample_r(r : np.ndarray, g_upscaled : np.ndarray) -> np.ndarray:
     g_r, _g_g1, _g_b, _g_g2 = bayer_to_rgbg(g_upscaled)
     return resample_channel(r, g_r, g_hf_cut, BayerPatternPosition.TOP_LEFT)
 
-def debayer(image : Union[RawRgbgData_BaseType]) -> Optional[RawDebayerData]:
-    if not(image.is_valid()):
-        return None
+def debayer(image : Union[RawBayerData_BaseType]) -> Optional[RawDemosaicData]:
     
-    r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
+    r, g1, b, g2 = bayer_to_rgbg(image.sensor_scaled)
     wb_coeff = image.cam_wb.get_reciprocal_multipliers()
 
     g_up = resample_g_to_full_resolution(g1, g2) * wb_coeff[1]
@@ -197,7 +195,7 @@ def debayer(image : Union[RawRgbgData_BaseType]) -> Optional[RawDebayerData]:
 
     debayered =  np.dstack((r_up, g_up, b_up))
 
-    output = RawDebayerData(debayered, wb_coeff, wb_norm=False)
+    output = RawDemosaicData(debayered, wb_coeff, wb_norm=False)
     output.mat_xyz = image.cam_wb.get_matrix()
     output.current_ev = image.current_ev
     return output

--- a/debayer/edge_assisted_gaussian.py
+++ b/debayer/edge_assisted_gaussian.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, Union
 import cv2
 import numpy as np
 
-from pySP.base_types.image_base import RawDemosaicData, RawBayerData_BaseType
+from pySP.base_types.image_base import RawDemosaicData, RawRggbBayerData_BaseType
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
 from pySP.debayer.gaussian import CV2_DEFAULT_KERNEL_SIGMA, CV2_DEFAULT_UNNORM_GAUSSIAN_KERNEL, BayerPatternPosition, get_rgbg_kernel
 
@@ -185,7 +185,7 @@ def resample_r(r : np.ndarray, g_upscaled : np.ndarray) -> np.ndarray:
     g_r, _g_g1, _g_b, _g_g2 = bayer_to_rgbg(g_upscaled)
     return resample_channel(r, g_r, g_hf_cut, BayerPatternPosition.TOP_LEFT)
 
-def debayer(image : Union[RawBayerData_BaseType]) -> Optional[RawDemosaicData]:
+def debayer(image : RawRggbBayerData_BaseType) -> RawDemosaicData:
     
     r, g1, b, g2 = bayer_to_rgbg(image.sensor_scaled)
     wb_coeff = image.cam_wb.get_reciprocal_multipliers()

--- a/debayer/fast_resize.py
+++ b/debayer/fast_resize.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 import cv2
 import numpy as np
 
 from pySP.bayer_chan_mixer import bayer_to_rgbg
-from pySP.base_types.image_base import RawDemosaicData, RawBayerData_BaseType
+from pySP.base_types.image_base import RawDemosaicData, RawRggbBayerData_BaseType
 
-def debayer(image : RawBayerData_BaseType) -> Optional[RawDemosaicData]:
+def debayer(image : RawRggbBayerData_BaseType) -> RawDemosaicData:
     """Debayer by resizing channels to fit original resolution.
 
     This is fast but produces low-quality results. Divergence is left uncorrected.

--- a/debayer/fast_resize.py
+++ b/debayer/fast_resize.py
@@ -4,9 +4,9 @@ import cv2
 import numpy as np
 
 from pySP.bayer_chan_mixer import bayer_to_rgbg
-from pySP.base_types.image_base import RawDebayerData, RawRgbgData_BaseType
+from pySP.base_types.image_base import RawDemosaicData, RawBayerData_BaseType
 
-def debayer(image : RawRgbgData_BaseType) -> Optional[RawDebayerData]:
+def debayer(image : RawBayerData_BaseType) -> Optional[RawDemosaicData]:
     """Debayer by resizing channels to fit original resolution.
 
     This is fast but produces low-quality results. Divergence is left uncorrected.
@@ -17,14 +17,11 @@ def debayer(image : RawRgbgData_BaseType) -> Optional[RawDebayerData]:
     Returns:
         Optional[RawDebayerData]: Debayered image; None if image is not valid.
     """
-
-    if not(image.is_valid()):
-        return None
     
     wb_coeff = image.cam_wb.get_reciprocal_multipliers()
 
     def debayer_nearest() -> np.ndarray:
-        r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
+        r, g1, b, g2 = bayer_to_rgbg(image.sensor_scaled)
 
         rgb = np.zeros((r.shape[0], r.shape[1], 3), dtype=np.float32)
 
@@ -41,9 +38,9 @@ def debayer(image : RawRgbgData_BaseType) -> Optional[RawDebayerData]:
         rgb[:,:,0] = r * wb_coeff[0]
         rgb[:,:,2] = b * wb_coeff[2]
 
-        return cv2.resize(rgb, (image.bayer_data_scaled.shape[1], image.bayer_data_scaled.shape[0]))
+        return cv2.resize(rgb, (image.sensor_scaled.shape[1], image.sensor_scaled.shape[0]))
 
-    output = RawDebayerData(debayer_nearest(), wb_coeff, wb_norm=False)
+    output = RawDemosaicData(debayer_nearest(), wb_coeff, wb_norm=False)
     output.mat_xyz = image.cam_wb.get_matrix()
     output.current_ev = image.current_ev
     return output

--- a/image.py
+++ b/image.py
@@ -146,6 +146,8 @@ class RawBayerDataFromRaw(RawBayerData):
                 reader = BytesIO(filename_or_data)
 
             with rawpy.imread(reader) as in_dng:
+                # TODO - This might change depending on Bayer configuration. So far every file I've seen has had equal
+                #        saturation and black values on every channel.
                 chan_sat = in_dng.camera_white_level_per_channel
                 chan_black = in_dng.black_level_per_channel
                 self.sensor_scaled = bayer_normalize(in_dng.raw_image, chan_black, chan_sat)

--- a/image.py
+++ b/image.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 from pySP.wb_cct.cam_wb import CameraWhiteBalanceControllerFromExif
 from .normalization import bayer_normalize
 from .debayer import debayer_ahd, debayer_fast, debayer_eag
-from .base_types.image_base import RawRgbgData_BaseType, RawDebayerData
+from .base_types.image_base import BayerPattern, RawBayerData_BaseType, RawRggbBayerData_BaseType, RawDemosaicData
 
 from .const import QualityDemosaic
 from math import log
@@ -70,13 +70,20 @@ def compute_ev_from_exif(filename_or_data : Union[str, bytes]) -> float:
 
     return compute_ev(iso, exp_time, f_stop)
 
-class RawRgbgData(RawRgbgData_BaseType):
-    def __init__(self):
-        """Base class for storing raw RGBG Bayer sensor data.
-        """
-        super().__init__()
+def reversible_transform_rggb(sensor_data : np.ndarray, bayer_pattern : BayerPattern):
+    if bayer_pattern == BayerPattern.Rggb:
+        return sensor_data
+    elif bayer_pattern == BayerPattern.Bggr:
+        return np.rot90(sensor_data, k=2)
+    elif bayer_pattern == BayerPattern.Gbrg:
+        return np.flip(sensor_data, axis=1)
+    elif bayer_pattern == BayerPattern.Grbg:
+        return np.flip(sensor_data, axis=0)
+    raise NotImplementedError(str(bayer_pattern) + " not implemented!")
 
-    def debayer(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> Optional[RawDebayerData]:
+class RawRggbBayerData(RawRggbBayerData_BaseType):
+
+    def demosaic(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> RawDemosaicData:
         """Debayers (demosaics) this image to a new RawDebayerData object.
 
         This does not modify the original data in any way. All image properties are copied to the new image.
@@ -90,16 +97,36 @@ class RawRgbgData(RawRgbgData_BaseType):
         """
 
         if quality == QualityDemosaic.Best:
-            return debayer_ahd(self, postprocess_stages=postprocess_steps)
+            debayered = debayer_ahd(self, postprocess_stages=postprocess_steps)
         elif quality == QualityDemosaic.Fast:
-            return debayer_eag(self)
+            debayered = debayer_eag(self)
         elif quality == QualityDemosaic.Draft:
-            return debayer_fast(self)
+            debayered = debayer_fast(self)
         else:
             raise NotImplementedError("Quality mode not implemented: %s" % str(quality))
+        
+        # TODO - Change this to remove WB from demosaic methods
 
+        # Revert any transforms needed to make data RGGB
+        debayered.image = reversible_transform_rggb(debayered.image, self.source_pattern)
 
-class RawRgbgDataFromRaw(RawRgbgData):
+        return debayered
+
+class RawBayerData(RawBayerData_BaseType):
+    def __init__(self):
+        """Base class for storing raw RGBG Bayer sensor data.
+        """
+        super().__init__()
+
+    def to_rggb(self):
+        rggb = reversible_transform_rggb(self.sensor_scaled, self.sensor_pattern)
+        return RawRggbBayerData(rggb, self.cam_wb.copy(), self.current_ev, self.lim_sat, self.sensor_pattern)
+    
+    def demosaic(self, quality : QualityDemosaic, postprocess_steps : int = 1) -> RawDemosaicData:
+        rggb = self.to_rggb()
+        return rggb.demosaic(quality, postprocess_steps)
+
+class RawBayerDataFromRaw(RawBayerData):
     def __init__(self, filename_or_data : Union[str, bytes]):
         """Class for storing RGBG Bayer sensor data from a raw file.
 
@@ -112,7 +139,6 @@ class RawRgbgDataFromRaw(RawRgbgData):
         """
 
         super().__init__()
-        self.__is_valid         : bool       = False
 
         try:
             reader = filename_or_data
@@ -122,7 +148,34 @@ class RawRgbgDataFromRaw(RawRgbgData):
             with rawpy.imread(reader) as in_dng:
                 chan_sat = in_dng.camera_white_level_per_channel
                 chan_black = in_dng.black_level_per_channel
-                self.bayer_data_scaled = bayer_normalize(in_dng.raw_image, chan_black, chan_sat)
+                self.sensor_scaled = bayer_normalize(in_dng.raw_image, chan_black, chan_sat)
+
+                if in_dng.raw_pattern.shape != (2,2):
+                    raise ValueError("Raw has unsupported Bayer pattern, cannot continue!")
+                
+                try:
+                    raw_cfa_planes = in_dng.color_desc.decode('ascii')
+                except UnicodeDecodeError:
+                    raise ValueError("Raw has unknown color array, %s" % str(in_dng.color_desc))
+                
+                if ''.join(sorted(list(set(raw_cfa_planes.upper())))) != "BGR":
+                    raise ValueError("Raw has unsupported colors, %s" % raw_cfa_planes)
+                
+                try:
+                    raw_cfa_decoded_pattern = ''.join(raw_cfa_planes[i] for i in in_dng.raw_pattern.flatten())
+                except IndexError:
+                    raise ValueError("Raw tried to index out-of-bounds color filter, malformed input!")
+                
+                if raw_cfa_decoded_pattern == "BGGR":
+                    self.sensor_pattern = BayerPattern.Bggr
+                elif raw_cfa_decoded_pattern == "RGGB":
+                    self.sensor_pattern = BayerPattern.Rggb
+                elif raw_cfa_decoded_pattern == "GBRG":
+                    self.sensor_pattern = BayerPattern.Gbrg
+                elif raw_cfa_decoded_pattern == "GRBG":
+                    self.sensor_pattern = BayerPattern.Grbg
+                else:
+                    raise NotImplementedError(f"Bayer pattern {raw_cfa_decoded_pattern} is not supported!")
             
             if type(filename_or_data) == str:
                 with open(filename_or_data, 'rb') as raw:
@@ -133,16 +186,13 @@ class RawRgbgDataFromRaw(RawRgbgData):
             self.cam_wb = CameraWhiteBalanceControllerFromExif(tags)
             
             self.current_ev = compute_ev_from_exif(filename_or_data)
-            if self.current_ev != np.inf:
-                self.__is_valid = True
+            if self.current_ev == np.inf:
+                raise ValueError("Error reading exposure value from raw!")
 
         except (rawpy.LibRawError, FileNotFoundError, IOError) as e:
-            self.__is_valid = False
-    
-    def is_valid(self) -> bool:
-        return self.__is_valid
+            raise ValueError("Raw couldn't be read! " + str(e))
 
-class RawDebayerDataFromRaw(RawDebayerData):
+class RawDebayerDataFromRaw(RawDemosaicData):
     def __init__(self, filename_or_data : Union[str, bytes]):
         """Class for storing RGB demosaiced data from a raw file.
 
@@ -187,7 +237,7 @@ class RawDebayerDataFromRaw(RawDebayerData):
             self.current_ev = compute_ev_from_exif(filename_or_data)
 
         except (rawpy.LibRawError, FileNotFoundError, IOError, OSError) as e:
-            print(e)
+            raise ValueError("Input raw couldn't be read! " + str(e))
     
         self._wb_applied = True
         self._wb_normalized = True

--- a/raw_bad_pixel_corr.py
+++ b/raw_bad_pixel_corr.py
@@ -2,7 +2,7 @@ import numpy as np
 import cv2
 from typing import List, Optional
 from .bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
-from .image import RawRgbgData
+from .image import RawBayerData
 
 # TODO - More aggressive checking for dimension sizes
 
@@ -27,7 +27,7 @@ def median2(chan : np.ndarray) -> np.ndarray:
     flattened = np.array([chan, chan_e_neighbour, chan_s_neighbour, chan_se_neighbour])
     return np.median(flattened, axis=0)
 
-def find_erroneous_pixels_threshold(image : RawRgbgData, min_delta : float = 0.025, min_neighbour_count : int = 5) -> List[np.ndarray]:
+def find_erroneous_pixels_threshold(image : RawBayerData, min_delta : float = 0.025, min_neighbour_count : int = 5) -> List[np.ndarray]:
     """Finds shared erroneous pixels on each color channel based on differences from its 8
     neighbouring pixels. Hot pixels are considered as pixels that are greater than some
     fixed difference from their neighbours.
@@ -59,12 +59,12 @@ def find_erroneous_pixels_threshold(image : RawRgbgData, min_delta : float = 0.0
         return np.sum(higher, axis=0) > min_neighbour_count
 
     masks = []
-    for chan in bayer_to_rgbg(image.bayer_data_scaled):
+    for chan in bayer_to_rgbg(image.sensor_scaled):
         masks.append(find_erroneous_pixels_threshold_chan(chan))
 
     return masks
 
-def find_erroneous_pixels_median(image : RawRgbgData, multiplier : float = 1.5, quantile : float = 0.9999) -> List[np.ndarray]:
+def find_erroneous_pixels_median(image : RawBayerData, multiplier : float = 1.5, quantile : float = 0.9999) -> List[np.ndarray]:
     """Finds erroneous pixels on each color channel based on differences from
     a small median blur.
 
@@ -79,7 +79,7 @@ def find_erroneous_pixels_median(image : RawRgbgData, multiplier : float = 1.5, 
 
     masks : List[np.ndarray] = []
 
-    for chan in bayer_to_rgbg(image.bayer_data_scaled):
+    for chan in bayer_to_rgbg(image.sensor_scaled):
         chan_blur = median2(chan)
         delta = np.abs(chan - chan_blur)
         noise_floor = np.mean(delta)
@@ -132,7 +132,7 @@ def find_shared_pixels(erroneous_mask : List[List[np.ndarray]], min_ratio : floa
     
     return masks
 
-def repair_bad_pixels(image : RawRgbgData, masks : List[np.ndarray]):
+def repair_bad_pixels(image : RawBayerData, masks : List[np.ndarray]):
     """Infill color channels in an image based on bad pixel masks.
 
     Args:
@@ -143,9 +143,9 @@ def repair_bad_pixels(image : RawRgbgData, masks : List[np.ndarray]):
     if len(masks) != 4:
         return
     
-    chans = bayer_to_rgbg(image.bayer_data_scaled)
+    chans = bayer_to_rgbg(image.sensor_scaled)
     new_chans = []
     for chan, mask in zip(chans, masks):
         new_chans.append(cv2.inpaint(chan, mask.astype(np.uint8) * 255, 3, cv2.INPAINT_NS))
     
-    image.bayer_data_scaled = rgbg_to_bayer(new_chans[0], new_chans[1], new_chans[2], new_chans[3])
+    image.sensor_scaled = rgbg_to_bayer(new_chans[0], new_chans[1], new_chans[2], new_chans[3])

--- a/raw_correction.py
+++ b/raw_correction.py
@@ -2,9 +2,9 @@ import numpy as np
 import cv2
 
 from pySP.bayer_chan_mixer import bayer_to_rgbg, rgbg_to_bayer
-from .image import RawRgbgData
+from .image import RawBayerData
 
-def dark_frame_subtraction(raw : RawRgbgData, dark_frame : RawRgbgData):
+def dark_frame_subtraction(raw : RawBayerData, dark_frame : RawBayerData):
     """Remove dark current noise from an image.
 
     Args:
@@ -13,7 +13,7 @@ def dark_frame_subtraction(raw : RawRgbgData, dark_frame : RawRgbgData):
     """
     return np.copy(raw)
 
-def bias_frame_subtraction(raw : RawRgbgData, bias_frame : RawRgbgData):
+def bias_frame_subtraction(raw : RawBayerData, bias_frame : RawBayerData):
     """Remove fixed-pattern noise from an image.
 
     Args:
@@ -22,7 +22,7 @@ def bias_frame_subtraction(raw : RawRgbgData, bias_frame : RawRgbgData):
     """
     return np.copy(raw)
 
-def flat_frame_correction(image : RawRgbgData, flat : RawRgbgData, clamp_high : bool = False):
+def flat_frame_correction(image : RawBayerData, flat : RawBayerData, clamp_high : bool = False):
     """Apply flat-frame correction in-place to an image.
 
     The output for this method will always be a valid image, but steps are taken in-case of problematic data:
@@ -36,11 +36,8 @@ def flat_frame_correction(image : RawRgbgData, flat : RawRgbgData, clamp_high : 
         clamp_high (bool, optional): True to clamp corrected photosites at 1. Breaks HDR images but useful elsewhere. Defaults to False.
     """
 
-    if not(image.is_valid() and flat.is_valid()):
-        return
-
-    r, g1, b, g2 = bayer_to_rgbg(image.bayer_data_scaled)
-    flat_r, flat_g1, flat_b, flat_g2 = bayer_to_rgbg(flat.bayer_data_scaled)
+    r, g1, b, g2 = bayer_to_rgbg(image.sensor_scaled)
+    flat_r, flat_g1, flat_b, flat_g2 = bayer_to_rgbg(flat.sensor_scaled)
 
     def correct_channel(chan : np.ndarray, chan_flat : np.ndarray) -> np.ndarray:
         # TODO - Add dark frame correction, currently we assume dark frame is zero
@@ -60,7 +57,7 @@ def flat_frame_correction(image : RawRgbgData, flat : RawRgbgData, clamp_high : 
 
         return output
 
-    image.bayer_data_scaled = rgbg_to_bayer(correct_channel(r, flat_r),
+    image.sensor_scaled = rgbg_to_bayer(correct_channel(r, flat_r),
                                             correct_channel(g1, flat_g1),
                                             correct_channel(b, flat_b),
                                             correct_channel(g2, flat_g2))

--- a/raw_hdr.py
+++ b/raw_hdr.py
@@ -1,5 +1,5 @@
 from pySP.bayer_chan_mixer import rgbg_to_bayer
-from .image import RawBayerData, RawDemosaicData
+from .image import RawRggbBayerData, RawDemosaicData
 from .colorize.transform import cam_to_lin_srgb
 import numpy as np
 from typing import Tuple, List, Optional
@@ -82,7 +82,7 @@ def fuse_exposures_from_debayer(in_exposures : List[RawDemosaicData], target_ev 
 
     return (sum_pixel, debug_count_references)
 
-def fuse_exposures_to_raw(in_exposures : List[RawBayerData], target_ev : Optional[float] = None) -> Optional[Tuple[RawBayerData, np.ndarray]]:
+def fuse_exposures_to_raw(in_exposures : List[RawRggbBayerData], target_ev : Optional[float] = None) -> Optional[Tuple[RawRggbBayerData, np.ndarray]]:
     """Fuse exposures to a new HDR raw image from a list of raw images while preserving the Bayer pattern.
 
     This method operates in sensor-space so is unaffected by response curves or sensor saturation.
@@ -147,7 +147,8 @@ def fuse_exposures_to_raw(in_exposures : List[RawBayerData], target_ev : Optiona
         sum_pixel = np.divide(sum_pixel, sum_weight)
     sum_pixel = np.where(sum_weight == 0, max_exposure, sum_pixel)
 
-    hdr_image = RawBayerData()
+    hdr_image = RawRggbBayerData()
+    hdr_image.source_pattern = in_exposures[0].source_pattern
     hdr_image.sensor_scaled = sum_pixel
     hdr_image.current_ev = target_ev
     hdr_image.lim_sat = max(ev_offsets)

--- a/raw_hdr.py
+++ b/raw_hdr.py
@@ -1,10 +1,10 @@
 from pySP.bayer_chan_mixer import rgbg_to_bayer
-from .image import RawRgbgData, RawDebayerData
+from .image import RawBayerData, RawDemosaicData
 from .colorize.transform import cam_to_lin_srgb
 import numpy as np
 from typing import Tuple, List, Optional
 
-def fuse_exposures_from_debayer(in_exposures : List[RawDebayerData], target_ev : Optional[float] = None) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+def fuse_exposures_from_debayer(in_exposures : List[RawDemosaicData], target_ev : Optional[float] = None) -> Optional[Tuple[np.ndarray, np.ndarray]]:
     """Fuse exposures to linearized sRGB HDR from a list of debayered images.
 
     This method operates in sensor-space so is unaffected by response curves or sensor saturation.
@@ -23,7 +23,7 @@ def fuse_exposures_from_debayer(in_exposures : List[RawDebayerData], target_ev :
         Optional[Tuple[np.ndarray, np.ndarray]]: (Linearized sRGB image, debug buffer tracking amount of contributions for each pixel); None if no valid images were provided.
     """
 
-    valid_exposures : List[RawDebayerData] = []
+    valid_exposures : List[RawDemosaicData] = []
     
     for exposure in in_exposures:
         if exposure.is_valid():
@@ -82,7 +82,7 @@ def fuse_exposures_from_debayer(in_exposures : List[RawDebayerData], target_ev :
 
     return (sum_pixel, debug_count_references)
 
-def fuse_exposures_to_raw(in_exposures : List[RawRgbgData], target_ev : Optional[float] = None) -> Optional[Tuple[RawRgbgData, np.ndarray]]:
+def fuse_exposures_to_raw(in_exposures : List[RawBayerData], target_ev : Optional[float] = None) -> Optional[Tuple[RawBayerData, np.ndarray]]:
     """Fuse exposures to a new HDR raw image from a list of raw images while preserving the Bayer pattern.
 
     This method operates in sensor-space so is unaffected by response curves or sensor saturation.
@@ -104,60 +104,54 @@ def fuse_exposures_to_raw(in_exposures : List[RawRgbgData], target_ev : Optional
     Returns:
         Optional[Tuple[HdrRgbgData, np.ndarray]]: (HDR Bayer image, debug buffer tracking amount of contributions for each pixel); None if no valid images were provided.
     """
-
-    valid_exposures : List[RawRgbgData] = []
     
-    for exposure in in_exposures:
-        if exposure.is_valid():
-            valid_exposures.append(exposure)
-    
-    if len(valid_exposures) == 0:
+    if len(in_exposures) == 0:
         return None
 
     if target_ev == None:
         target_ev = 0
-        for exposure in valid_exposures:
+        for exposure in in_exposures:
             target_ev += exposure.current_ev
-        target_ev /= len(valid_exposures)
+        target_ev /= len(in_exposures)
     else:
         assert target_ev > 0
     
     ev_offsets : List[float] = []
-    for exposure in valid_exposures:
+    for exposure in in_exposures:
         ev_offsets.append(2 ** (exposure.current_ev - target_ev))
     
-    debug_count_references = np.zeros(shape=valid_exposures[0].bayer_data_scaled.shape, dtype=np.int32)
-    sum_pixel = np.zeros_like(valid_exposures[0].bayer_data_scaled)
-    sum_weight = np.zeros_like(valid_exposures[0].bayer_data_scaled)
+    debug_count_references = np.zeros(shape=in_exposures[0].sensor_scaled.shape, dtype=np.int32)
+    sum_pixel = np.zeros_like(in_exposures[0].sensor_scaled)
+    sum_weight = np.zeros_like(in_exposures[0].sensor_scaled)
 
     # Since we'll correct WB later, add additional bias on WB to reduce noise gain after WB is scaled
-    wb_coeff = valid_exposures[0].cam_wb.get_reciprocal_multipliers()
-    bayer_noise_weight = np.ones((valid_exposures[0].bayer_data_scaled.shape[0] // 2, valid_exposures[0].bayer_data_scaled.shape[1] // 2), dtype=np.float32)
+    wb_coeff = in_exposures[0].cam_wb.get_reciprocal_multipliers()
+    bayer_noise_weight = np.ones((in_exposures[0].sensor_scaled.shape[0] // 2, in_exposures[0].sensor_scaled.shape[1] // 2), dtype=np.float32)
     bayer_noise_weight = rgbg_to_bayer(bayer_noise_weight * wb_coeff[0],
                                        wb_coeff[1],
                                        wb_coeff[2],
                                        wb_coeff[1])
 
-    for exposure, ev_offset in zip(valid_exposures, ev_offsets):
+    for exposure, ev_offset in zip(in_exposures, ev_offsets):
         bias = 1.6 ** (-0.1 * np.abs(ev_offset * bayer_noise_weight))       # Bias stacking to favor closest EV - this is just a random curve that should weight
-        weights = (0.5 - np.abs(exposure.bayer_data_scaled - 0.5)) * bias   #     target EVs (~0) at 1 and EVs up to 16x gaps still favorably (ISO 1600 is still good)
+        weights = (0.5 - np.abs(exposure.sensor_scaled - 0.5)) * bias   #     target EVs (~0) at 1 and EVs up to 16x gaps still favorably (ISO 1600 is still good)
         sum_weight += weights
-        sum_pixel += exposure.bayer_data_scaled * weights * ev_offset
+        sum_pixel += exposure.sensor_scaled * weights * ev_offset
 
         debug_count_references[weights > 0] += 1
         
     offset_max_exposure = np.argmax(ev_offsets)
-    max_exposure = np.multiply(valid_exposures[offset_max_exposure].bayer_data_scaled, ev_offsets[offset_max_exposure])
+    max_exposure = np.multiply(in_exposures[offset_max_exposure].sensor_scaled, ev_offsets[offset_max_exposure])
 
     with np.errstate(divide='ignore', invalid='ignore'):    # Expected, we filter out bad results next
         sum_pixel = np.divide(sum_pixel, sum_weight)
     sum_pixel = np.where(sum_weight == 0, max_exposure, sum_pixel)
 
-    hdr_image = RawRgbgData()
-    hdr_image.bayer_data_scaled = sum_pixel
+    hdr_image = RawBayerData()
+    hdr_image.sensor_scaled = sum_pixel
     hdr_image.current_ev = target_ev
     hdr_image.lim_sat = max(ev_offsets)
-    hdr_image.cam_wb = valid_exposures[0].cam_wb.copy()     # TODO (BUG) - Fix broken D-series balancing
+    hdr_image.cam_wb = in_exposures[0].cam_wb.copy()     # TODO (BUG) - Fix broken D-series balancing
     hdr_image.set_hdr(True)
 
     return (hdr_image, debug_count_references)


### PR DESCRIPTION
Simple non-destructive operations can transform any Bayer sensor to RGGB which was the assumed sensor format for pySP. This changes the imaging pipeline by adding an intermediary class RawRggbBayerData which uses reversible transforms to transform the input sensor data to RGGB where all imaging operations can operate like normal. On debayering, it applies the inverse transform after. Some image techniques (structural instability, debayering, raw HDR) have been updated to explicitly force RGGB order since they need the channel separation to correspond to white balance inputs which are always RGB order.

This has been tested with my old Lumix plus the Yi M1, previously the Lumix displayed incorrect colors (BGGR sensor) while Yi was fine. Both now have correct colors. There is in theory some performance loss having to waste time on transforms but np.flip and np.rotate are fast enough to be basically unnoticeable.