### PR TITLE
Fixup CMat multiplication order

### DIFF
--- a/colorize/transform.py
+++ b/colorize/transform.py
@@ -38,7 +38,7 @@ def cam_to_rgb_norm(rgb : np.ndarray, cam_xyz_matrix : MatXyzToCamera, destinati
         rgb = clip_rgb(rgb)
     
     mat_rgb_to_xyz_d_cam = destination_colorspace.mat_to_xyz(cam_xyz_matrix.xyz.tolist())
-    color_mat = np.matmul(mat_rgb_to_xyz_d_cam, cam_xyz_matrix.mat)
+    color_mat = np.matmul(cam_xyz_matrix.mat, mat_rgb_to_xyz_d_cam)
 
     # Normalize to remove tint
     # Cam -> XYZ is imperfect with WB so you end up with tint on RGB channels


### PR DESCRIPTION
Order of operations was backwards - this worked mostly fine on my Yi M1 and Leica sample files but broke colors on my Lumix cameras. This now makes color consistent with most software.